### PR TITLE
feat: marketplace registry, sample plugin, and Pages deployment

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -26,13 +26,13 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload site artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           # Repo root is the published site: plugin-registry.json and each
           # plugin folder are served from the domain root. CNAME and .nojekyll
@@ -41,4 +41,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,44 @@
+name: Deploy to GitHub Pages
+
+# Publishes the plugin registry and bundled plugin assets to GitHub Pages,
+# served at the custom domain in CNAME (plugins.geolibre.app).
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; cancel in-progress runs for the same group.
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload site artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Repo root is the published site: plugin-registry.json and each
+          # plugin folder are served from the domain root. CNAME and .nojekyll
+          # are included so the custom domain and as-is file serving stick.
+          path: .
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+plugins.geolibre.app

--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ copy-ready template.
 Plugins are **trusted code** that runs with full app privileges, so the registry
 is curated: open a pull request and a maintainer reviews it before it ships.
 
+> **Start from the template:** the
+> [geolibre-plugin-template](https://github.com/opengeos/geolibre-plugin-template)
+> is the recommended starting point for plugin development. It includes a
+> MapLibre control wrapper, a `plugin.json` manifest, a GeoLibre plugin entry
+> point, and a build that produces the bundle layout below. The
+> [`sample/`](./sample) plugin here is a minimal in-repo example.
+
 ### 1. Build a plugin entry
 
 Your `entry` is a single self-contained ES module — bundle your dependencies in;

--- a/README.md
+++ b/README.md
@@ -1,2 +1,81 @@
-# geolibre-plugins
-A plugin marketplace for GeoLibre
+# GeoLibre Plugins
+
+The plugin marketplace registry for [GeoLibre](https://github.com/opengeos/GeoLibre).
+
+This repository is published to GitHub Pages at **https://plugins.geolibre.app**
+and hosts:
+
+- `plugin-registry.json` — the curated index the GeoLibre Manage Plugins dialog
+  reads (`https://plugins.geolibre.app/plugin-registry.json`).
+- One folder per plugin (e.g. `sample/`) containing its `plugin.json` manifest
+  and built assets.
+
+GitHub Pages serves these files with permissive CORS, so the GeoLibre app
+(running on a different origin) can fetch the registry and each plugin bundle.
+
+## Registry format
+
+`plugin-registry.json` is an object with a `plugins` array. Each entry:
+
+```json
+{
+  "id": "my-plugin",
+  "name": "My Plugin",
+  "version": "1.0.0",
+  "description": "Optional short description",
+  "author": "Author name",
+  "homepage": "https://github.com/owner/my-plugin",
+  "manifestUrl": "my-plugin/plugin.json",
+  "categories": ["Example"],
+  "minGeoLibreVersion": "0.9.0"
+}
+```
+
+- `id`, `name`, `version`, and `manifestUrl` are required; the rest are optional.
+- `manifestUrl` may be relative (resolved against this registry's URL, so a
+  same-origin plugin hosted here uses e.g. `my-plugin/plugin.json`) or an
+  absolute HTTPS URL pointing at a plugin hosted elsewhere.
+- `homepage` must be `http(s)`; other schemes are dropped by the app.
+- `minGeoLibreVersion` gates installation against the running app version.
+
+## Plugin manifest
+
+Each plugin folder has a `plugin.json` (the same contract GeoLibre's external
+plugin loader expects):
+
+```json
+{
+  "id": "my-plugin",
+  "name": "My Plugin",
+  "version": "1.0.0",
+  "entry": "index.js",
+  "style": "style.css"
+}
+```
+
+`entry` must be a self-contained ES module exporting a `GeoLibrePlugin` as the
+default or a named `plugin` export, with `id`/`name`/`version` matching the
+manifest. `entry` and `style` are resolved relative to the manifest, so keep
+them inside the plugin's own folder. See [`sample/`](./sample) for a minimal,
+copy-ready template.
+
+## Adding a plugin
+
+1. Add a folder `<id>/` with `plugin.json`, the built `entry` JS, and any
+   `style` CSS.
+2. Add an entry to `plugin-registry.json` pointing `manifestUrl` at
+   `<id>/plugin.json`.
+3. Open a pull request. On merge to `main`, the
+   [Deploy to GitHub Pages](.github/workflows/deploy-pages.yml) workflow
+   publishes the update to `plugins.geolibre.app`.
+
+## Deployment
+
+Pushing to `main` runs the Pages workflow, which uploads the repository root as
+the site. The custom domain is set by the `CNAME` file
+(`plugins.geolibre.app`); `.nojekyll` disables Jekyll so files are served
+verbatim.
+
+> One-time setup: enable **Settings → Pages → Source: GitHub Actions**, and add
+> a DNS `CNAME` record for `plugins.geolibre.app` pointing at
+> `opengeos.github.io`.

--- a/README.md
+++ b/README.md
@@ -59,15 +59,75 @@ manifest. `entry` and `style` are resolved relative to the manifest, so keep
 them inside the plugin's own folder. See [`sample/`](./sample) for a minimal,
 copy-ready template.
 
-## Adding a plugin
+## Contributing a plugin
 
-1. Add a folder `<id>/` with `plugin.json`, the built `entry` JS, and any
-   `style` CSS.
-2. Add an entry to `plugin-registry.json` pointing `manifestUrl` at
-   `<id>/plugin.json`.
-3. Open a pull request. On merge to `main`, the
-   [Deploy to GitHub Pages](.github/workflows/deploy-pages.yml) workflow
-   publishes the update to `plugins.geolibre.app`.
+Plugins are **trusted code** that runs with full app privileges, so the registry
+is curated: open a pull request and a maintainer reviews it before it ships.
+
+### 1. Build a plugin entry
+
+Your `entry` is a single self-contained ES module — bundle your dependencies in;
+relative `import`s are not resolved by the loader. It must export a
+`GeoLibrePlugin` as the default export or a named `plugin` export, and its
+`id` / `name` / `version` must match the `plugin.json` manifest. The minimal
+shape:
+
+```js
+export const plugin = {
+  id: "my-plugin",
+  name: "My Plugin",
+  version: "1.0.0",
+  activate(app) {
+    // add a control, layer, etc. using the app API
+  },
+  deactivate(app) {
+    // tear down whatever activate added
+  },
+};
+export default plugin;
+```
+
+External plugins must **not** set `activeByDefault`. The optional `style` CSS is
+injected globally, so scope your selectors (e.g. a plugin-specific class prefix);
+`hsl(var(--foreground))` and the other GeoLibre design tokens are available so a
+control can match the in-app light/dark theme. Copy [`sample/`](./sample) as a
+starting point.
+
+### 2. Add the plugin folder
+
+Create `<id>/` at the repo root containing `plugin.json`, the built `entry` JS,
+and any `style` CSS. Keep `entry`/`style` paths relative and inside the folder.
+
+### 3. Register it
+
+Add an entry to `plugin-registry.json` with `manifestUrl` pointing at
+`<id>/plugin.json` (relative) — or an absolute HTTPS URL if you host the plugin
+elsewhere. Set `minGeoLibreVersion` to the lowest GeoLibre version you support.
+
+### 4. Test locally
+
+Point a local GeoLibre build at your branch's registry, then open
+**Settings → Manage Plugins** and install it:
+
+```bash
+# serve this repo with CORS on http://localhost:8090, then build GeoLibre with:
+VITE_GEOLIBRE_PLUGIN_REGISTRY_URL=http://localhost:8090/plugin-registry.json
+```
+
+`http://localhost` and HTTPS registries are accepted; other schemes are rejected.
+
+### 5. Open a pull request
+
+On merge to `main`, the
+[Deploy to GitHub Pages](.github/workflows/deploy-pages.yml) workflow publishes
+the update to `plugins.geolibre.app`.
+
+### Updating a plugin
+
+Bump `version` in both the plugin's `plugin.json` **and** its registry entry,
+update the built assets, and open a PR. GeoLibre shows an **Update** action to
+users whose installed version is older than the registry version; uninstalling
+removes it at runtime.
 
 ## Deployment
 

--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "plugins": [
+    {
+      "id": "geolibre-sample-plugin",
+      "name": "Sample Plugin",
+      "version": "1.0.0",
+      "description": "A minimal example plugin that adds a button control to the map. Use it as a template for marketplace entries.",
+      "author": "GeoLibre",
+      "homepage": "https://github.com/opengeos/geolibre-plugins",
+      "manifestUrl": "sample/plugin.json",
+      "categories": ["Example"],
+      "minGeoLibreVersion": "0.9.0"
+    }
+  ]
+}

--- a/sample/index.js
+++ b/sample/index.js
@@ -1,0 +1,64 @@
+// Minimal GeoLibre external plugin used as the marketplace's sample / template.
+// It is a self-contained ES module that exports a `plugin` implementing the
+// GeoLibrePlugin contract, the same shape any external plugin must provide.
+// It ships style.css so its control is theme-aware in light and dark mode.
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+const STAR_PATH =
+  "M12 2.5l2.9 5.88 6.49.94-4.7 4.58 1.11 6.46L12 17.9l-5.8 3.05 1.1-6.46-4.69-4.58 6.49-.94L12 2.5z";
+
+// Built through the DOM API rather than innerHTML so the template models the
+// safe idiom for authors who later swap in dynamic content.
+function createStarIcon() {
+  const svg = document.createElementNS(SVG_NS, "svg");
+  svg.setAttribute("viewBox", "0 0 24 24");
+  svg.setAttribute("width", "18");
+  svg.setAttribute("height", "18");
+  svg.setAttribute("fill", "currentColor");
+  svg.setAttribute("aria-hidden", "true");
+  const path = document.createElementNS(SVG_NS, "path");
+  path.setAttribute("d", STAR_PATH);
+  svg.appendChild(path);
+  return svg;
+}
+
+const control = {
+  _container: null,
+  onAdd() {
+    const container = document.createElement("div");
+    container.className =
+      "maplibregl-ctrl maplibregl-ctrl-group geolibre-sample-plugin-control";
+    const button = document.createElement("button");
+    button.type = "button";
+    button.title = "GeoLibre Sample Plugin";
+    button.setAttribute("aria-label", "GeoLibre Sample Plugin");
+    button.appendChild(createStarIcon());
+    button.addEventListener("click", () => {
+      // Non-blocking feedback for the template. A real plugin would act on the
+      // map here, e.g. app.addGeoJsonLayer(...) captured from activate(app).
+      button.classList.toggle("is-active");
+      console.info("GeoLibre Sample Plugin button clicked.");
+    });
+    container.appendChild(button);
+    this._container = container;
+    return container;
+  },
+  onRemove() {
+    this._container?.remove();
+    this._container = null;
+  },
+};
+
+export const plugin = {
+  id: "geolibre-sample-plugin",
+  name: "Sample Plugin",
+  version: "1.0.0",
+  activate(app) {
+    app.addMapControl(control, "top-right");
+  },
+  deactivate(app) {
+    app.removeMapControl(control);
+  },
+};
+
+export default plugin;

--- a/sample/plugin.json
+++ b/sample/plugin.json
@@ -1,0 +1,8 @@
+{
+  "id": "geolibre-sample-plugin",
+  "name": "Sample Plugin",
+  "version": "1.0.0",
+  "description": "A minimal example plugin that adds a button control to the map.",
+  "entry": "index.js",
+  "style": "style.css"
+}

--- a/sample/style.css
+++ b/sample/style.css
@@ -1,0 +1,28 @@
+/*
+ * Theme the sample plugin's map control with GeoLibre's design tokens (defined
+ * globally on :root and .dark) so it adapts to the in-app light/dark theme. In
+ * dark mode --background/--popover are near-black and would fuse with the map,
+ * so the control uses the lighter --secondary surface plus a border to stay
+ * visible, and the icon uses --foreground for contrast.
+ */
+.geolibre-sample-plugin-control.maplibregl-ctrl-group {
+  background: hsl(var(--secondary));
+  border: 1px solid hsl(var(--border));
+}
+
+.geolibre-sample-plugin-control button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  color: hsl(var(--foreground));
+}
+
+.geolibre-sample-plugin-control button:hover {
+  background: hsl(var(--foreground) / 0.1);
+}
+
+.geolibre-sample-plugin-control button.is-active {
+  background: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
+}


### PR DESCRIPTION
## Summary
- Seed the plugin marketplace served at https://plugins.geolibre.app: a curated plugin-registry.json and a minimal, theme-aware sample plugin (moved from the GeoLibre app's bundled copy).
- Add a GitHub Actions workflow that deploys the repo root to GitHub Pages on push to main.
- Add CNAME (plugins.geolibre.app) and .nojekyll, and document the registry/manifest format and how to add a plugin.

## One-time setup required (repo owner)
- Settings -> Pages -> Source: GitHub Actions.
- DNS: add a CNAME record for plugins.geolibre.app -> opengeos.github.io.

## Test plan
- [ ] Merge, confirm the Pages workflow runs and publishes.
- [ ] https://plugins.geolibre.app/plugin-registry.json and /sample/plugin.json resolve with CORS.
- [ ] GeoLibre Manage Plugins lists and installs the sample from the live registry (paired with the GeoLibre PR that points the default registry URL here).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin registry for discovering and managing GeoLibre plugins.
  * Sample plugin demonstrating integration, activation/deactivation, and a small UI control.

* **Documentation**
  * Expanded contributor guide covering registry schema, plugin manifest contract, build/test/PR workflow, versioning, and deployment notes.

* **Chores**
  * Automated site deployment to GitHub Pages with custom domain and deployment concurrency controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->