### PR TITLE
fix: header logo contrast against the teal header

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,3 +1,12 @@
+/* The colorful globe logo (esp. its green segments) fuses with the teal
+   header, so back it with a white circle for clear contrast. */
+.md-header__button.md-logo img {
+  background-color: #fff;
+  border-radius: 50%;
+  padding: 2px;
+  box-sizing: content-box;
+}
+
 /* Tighten the plugin catalog cards and give each a clear footer of links. */
 .md-typeset .grid.cards > ul > li {
   border-radius: 0.5rem;


### PR DESCRIPTION
## Summary
- The colorful globe logo (especially its green segments) fused with the teal header. Back the header logo with a white circle so it stays legible.

## Test plan
- [x] `mkdocs build --strict` passes
- [x] Verified locally: logo renders on a white circle in the header, clearly contrasting the teal background

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the documentation header logo visibility by adding a white circular background that enhances contrast against the teal header. This visual refinement makes the logo more prominent and distinctive within the documentation interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->