### PR TITLE
fix: refresh Elevation Profile bundle with desktop-export fix

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -13,7 +13,7 @@ There are **2** plugins in the registry. Install them from GeoLibre: open **Sett
 
     ---
 
-    Draw a line on the map to chart an elevation profile with distance, ascent/descent, and min/max stats, a metric/imperial toggle, and CSV/PNG export. Samples elevation from the Open-Meteo API.
+    Draw a line on the map to chart an elevation profile with distance, ascent/descent, and min/max stats, a metric/imperial toggle, and CSV/SVG export. Samples elevation from the Open-Meteo API.
 
     **Author:** Qiusheng Wu · **Version:** 0.1.0 · **Requires:** GeoLibre 0.9.0+
 

--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -16,7 +16,7 @@
       "id": "geolibre-elevation-profile",
       "name": "Elevation Profile",
       "version": "0.1.0",
-      "description": "Draw a line on the map to chart an elevation profile with distance, ascent/descent, and min/max stats, a metric/imperial toggle, and CSV/PNG export. Samples elevation from the Open-Meteo API.",
+      "description": "Draw a line on the map to chart an elevation profile with distance, ascent/descent, and min/max stats, a metric/imperial toggle, and CSV/SVG export. Samples elevation from the Open-Meteo API.",
       "author": "Qiusheng Wu",
       "homepage": "https://github.com/opengeos/geolibre-elevation-profile",
       "manifestUrl": "plugins/geolibre-elevation-profile/plugin.json",

--- a/plugins/geolibre-elevation-profile/index.js
+++ b/plugins/geolibre-elevation-profile/index.js
@@ -354,6 +354,7 @@ var pointCollection = (coords) => ({
 */
 var ElevationProfileControl = class {
 	_options;
+	_exportTextFile;
 	_state;
 	_map;
 	_mapContainer;
@@ -386,9 +387,11 @@ var ElevationProfileControl = class {
 	* @param options - Optional configuration overrides
 	*/
 	constructor(options) {
+		const { exportTextFile, ...visual } = options ?? {};
+		this._exportTextFile = exportTextFile;
 		this._options = {
 			...DEFAULT_OPTIONS,
-			...options
+			...visual
 		};
 		this._options.maxSamples = Math.min(100, Math.max(2, Math.floor(this._options.maxSamples)));
 		this._state = {
@@ -813,13 +816,13 @@ var ElevationProfileControl = class {
 		csvButton.textContent = "CSV";
 		csvButton.title = "Download the profile as CSV";
 		csvButton.addEventListener("click", () => this._exportCsv());
-		const pngButton = document.createElement("button");
-		pngButton.type = "button";
-		pngButton.className = "elevation-profile-button elevation-profile-button-sm";
-		pngButton.textContent = "PNG";
-		pngButton.title = "Download the chart as a PNG image";
-		pngButton.addEventListener("click", () => this._exportPng());
-		exportRow.append(exportLabel, csvButton, pngButton);
+		const svgButton = document.createElement("button");
+		svgButton.type = "button";
+		svgButton.className = "elevation-profile-button elevation-profile-button-sm";
+		svgButton.textContent = "SVG";
+		svgButton.title = "Save the chart as an SVG image";
+		svgButton.addEventListener("click", () => this._exportSvg());
+		exportRow.append(exportLabel, csvButton, svgButton);
 		this._exportEl = exportRow;
 		panel.append(header, actions, status, stats, chart, readout, exportRow);
 		if (typeof ResizeObserver !== "undefined") {
@@ -957,13 +960,31 @@ var ElevationProfileControl = class {
 	_exportCsv() {
 		if (this._profilePoints.length < 2) return;
 		const csv = profileToCsv(this._profilePoints, this._sampledCoords);
-		this._downloadBlob(new Blob([csv], { type: "text/csv;charset=utf-8" }), "elevation-profile.csv");
+		this._saveFile("elevation-profile.csv", csv, {
+			description: "CSV",
+			extensions: ["csv"],
+			mimeType: "text/csv"
+		});
 	}
-	_exportPng() {
+	_exportSvg() {
+		const svg = this._buildExportSvg();
+		if (!svg) return;
+		this._saveFile("elevation-profile.svg", svg, {
+			description: "SVG image",
+			extensions: ["svg"],
+			mimeType: "image/svg+xml"
+		});
+	}
+	/**
+	* Serialize the rendered chart into a standalone SVG string with the
+	* presentation styles inlined (external CSS does not travel with the file) and
+	* a solid background. Returns null when there is no chart to export.
+	*/
+	_buildExportSvg() {
 		const svg = this._svgEl;
-		if (!svg || this._profilePoints.length < 2) return;
+		if (!svg || this._profilePoints.length < 2) return null;
 		const viewBox = svg.getAttribute("viewBox")?.split(" ").map(Number);
-		if (!viewBox || viewBox.length < 4) return;
+		if (!viewBox || viewBox.length < 4) return null;
 		const width = viewBox[2];
 		const height = viewBox[3];
 		const clone = svg.cloneNode(true);
@@ -998,45 +1019,20 @@ var ElevationProfileControl = class {
 		rect.setAttribute("height", `${height}`);
 		rect.setAttribute("fill", background && background !== "rgba(0, 0, 0, 0)" ? background : "#ffffff");
 		clone.insertBefore(rect, clone.firstChild);
-		const svgText = new XMLSerializer().serializeToString(clone);
-		const url = URL.createObjectURL(new Blob([svgText], { type: "image/svg+xml;charset=utf-8" }));
-		const image = new Image();
-		image.onload = () => {
-			try {
-				const scale = 2;
-				const canvas = document.createElement("canvas");
-				canvas.width = Math.round(width * scale);
-				canvas.height = Math.round(height * scale);
-				const ctx = canvas.getContext("2d");
-				if (!ctx) {
-					this._setStatus("Could not export the chart as PNG.");
-					return;
-				}
-				ctx.scale(scale, scale);
-				ctx.drawImage(image, 0, 0, width, height);
-				canvas.toBlob((blob) => {
-					if (blob) this._downloadBlob(blob, "elevation-profile.png");
-					else this._downloadDataUrl(canvas.toDataURL("image/png"), "elevation-profile.png");
-				}, "image/png");
-			} catch {
-				this._setStatus("Could not export the chart as PNG.");
-			} finally {
-				URL.revokeObjectURL(url);
-			}
-		};
-		image.onerror = () => {
-			URL.revokeObjectURL(url);
-			this._setStatus("Could not export the chart as PNG.");
-		};
-		image.src = url;
+		return `<?xml version="1.0" encoding="UTF-8"?>\n${new XMLSerializer().serializeToString(clone)}`;
 	}
-	_downloadDataUrl(dataUrl, filename) {
-		const anchor = document.createElement("a");
-		anchor.href = dataUrl;
-		anchor.download = filename;
-		document.body.appendChild(anchor);
-		anchor.click();
-		anchor.remove();
+	/**
+	* Save text content. Prefers the host's file save (a native dialog under Tauri,
+	* a browser download on the web); falls back to a browser download when the
+	* plugin runs standalone without a host.
+	*/
+	_saveFile(filename, content, options) {
+		if (this._exportTextFile) {
+			this._exportTextFile(filename, content, options);
+			return;
+		}
+		const blob = new Blob([content], { type: options.mimeType ?? "text/plain;charset=utf-8" });
+		this._downloadBlob(blob, filename);
 	}
 	_downloadBlob(blob, filename) {
 		const url = URL.createObjectURL(blob);
@@ -1176,10 +1172,11 @@ async function maybeHandleDeepLink(consumer, params) {
 var control = null;
 var position = "top-left";
 var pendingState = null;
-function createControl() {
+function createControl(app) {
 	const next = new ElevationProfileControl({
 		collapsed: pendingState?.collapsed ?? true,
-		unitSystem: pendingState?.unitSystem ?? "metric"
+		unitSystem: pendingState?.unitSystem ?? "metric",
+		exportTextFile: app.exportTextFile ? (filename, content, options) => app.exportTextFile?.(filename, content, options) : void 0
 	});
 	if (pendingState) next.setState(pendingState);
 	return next;
@@ -1205,7 +1202,7 @@ var plugin = {
 	version: "0.1.0",
 	urlParameterNames: [ELEVATION_LINE_PARAM],
 	activate(app) {
-		control = control ?? createControl();
+		control = control ?? createControl(app);
 		if (!app.addMapControl(control, position)) {
 			control = null;
 			return false;

--- a/plugins/geolibre-elevation-profile/plugin.json
+++ b/plugins/geolibre-elevation-profile/plugin.json
@@ -2,7 +2,7 @@
   "id": "geolibre-elevation-profile",
   "name": "Elevation Profile",
   "version": "0.1.0",
-  "description": "Draw a line on the map to chart its elevation profile, with distance, ascent/descent, and min/max stats, plus CSV/PNG export.",
+  "description": "Draw a line on the map to chart its elevation profile, with distance, ascent/descent, and min/max stats, plus CSV/SVG export.",
   "entry": "index.js",
   "style": "style.css"
 }


### PR DESCRIPTION
## Summary
- Refresh the vendored `geolibre-elevation-profile` bundle to the released build. The previously merged build's CSV/image export used a browser download that is a no-op in the Tauri desktop app (no save dialog); the new build saves through GeoLibre's host file API, so export works on both desktop and web.
- Image export is now SVG instead of PNG (the host file API is text-only; SVG round-trips it and is vector). Manifest and registry descriptions updated to "CSV/SVG export".
- Regenerated `docs/plugins.md` from the registry.

## Test plan
- [ ] In GeoLibre Desktop, draw a profile and click CSV / SVG: a native save dialog appears and the file is written.
- [ ] In the web app, CSV / SVG still download.
- [ ] `python scripts/generate_plugins_page.py` and `mkdocs build --strict` succeed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Elevation Profile plugin now exports results in CSV and SVG formats (previously CSV and PNG).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->