### PR TITLE
fix: refresh D2S bundle so server field defaults to ps2.d2s.org

### DIFF
--- a/plugins/geolibre-d2s/index.js
+++ b/plugins/geolibre-d2s/index.js
@@ -3218,9 +3218,10 @@ var PluginControl = class {
 	* @param options - Configuration options for the control
 	*/
 	constructor(options) {
+		const provided = Object.fromEntries(Object.entries(options ?? {}).filter(([, value]) => value !== void 0));
 		this._options = {
 			...DEFAULT_OPTIONS,
-			...options
+			...provided
 		};
 		this._state = {
 			collapsed: this._options.collapsed,


### PR DESCRIPTION
## Summary
- Refresh the bundled `plugins/geolibre-d2s/index.js` to pick up the source fix in opengeos/geolibre-d2s#4.
- Previously the plugin panel showed an empty server field because an absent saved state passed `serverUrl: undefined`, which clobbered the `DEFAULT_D2S_SERVER` default. The rebuilt bundle now pre-fills `https://ps2.d2s.org`.

## Test plan
- [ ] Install the plugin from this branch's registry in GeoLibre
- [ ] Open the plugin panel with no saved state and confirm the server field shows `https://ps2.d2s.org`