### PR TITLE
feat(sample): demonstrate plugin UI surface APIs

### DIFF
--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -4,8 +4,8 @@
     {
       "id": "geolibre-sample-plugin",
       "name": "Sample Plugin",
-      "version": "1.0.0",
-      "description": "A minimal example plugin that adds a button control to the map. Use it as a template for marketplace entries.",
+      "version": "1.1.0",
+      "description": "An example plugin that adds a map control and demonstrates the plugin UI surface APIs: a right-sidebar panel, a top toolbar menu, and a floating panel. Use it as a template for marketplace entries.",
       "author": "GeoLibre",
       "homepage": "https://github.com/opengeos/geolibre-plugins",
       "manifestUrl": "plugins/sample/plugin.json",

--- a/plugins/sample/index.js
+++ b/plugins/sample/index.js
@@ -1,11 +1,26 @@
-// Minimal GeoLibre external plugin used as the marketplace's sample / template.
+// GeoLibre external plugin used as the marketplace's sample / template.
 // It is a self-contained ES module that exports a `plugin` implementing the
 // GeoLibrePlugin contract, the same shape any external plugin must provide.
-// It ships style.css so its control is theme-aware in light and dark mode.
+//
+// Besides a theme-aware map control, it demonstrates the optional plugin UI
+// surface APIs: a right-sidebar panel, a top toolbar menu, and a floating
+// panel. Every UI-surface call is optional-chained, so on a host that does not
+// provide a given surface the plugin still works as a plain map control.
+// It ships style.css so its control and panels are theme-aware in light/dark.
 
 const SVG_NS = "http://www.w3.org/2000/svg";
 const STAR_PATH =
   "M12 2.5l2.9 5.88 6.49.94-4.7 4.58 1.11 6.46L12 17.9l-5.8 3.05 1.1-6.46-4.69-4.58 6.49-.94L12 2.5z";
+
+const RIGHT_PANEL_ID = "geolibre-sample-workbench";
+const FLOATING_PANEL_ID = "geolibre-sample-tools";
+const TOOLBAR_MENU_ID = "geolibre-sample-menu";
+
+// The host API captured in activate, so the map control's click handler can
+// drive the UI surfaces.
+let appApi = null;
+// Disposers returned by the register* calls; run on deactivate.
+const disposers = [];
 
 // Built through the DOM API rather than innerHTML so the template models the
 // safe idiom for authors who later swap in dynamic content.
@@ -22,6 +37,20 @@ function createStarIcon() {
   return svg;
 }
 
+// Fill a panel/card body with plain DOM. Returns a cleanup function the host
+// runs when the panel closes or is unregistered.
+function fillPanel(container, heading, body) {
+  const wrap = document.createElement("div");
+  wrap.className = "geolibre-sample-panel";
+  const title = document.createElement("h2");
+  title.textContent = heading;
+  const text = document.createElement("p");
+  text.textContent = body;
+  wrap.append(title, text);
+  container.appendChild(wrap);
+  return () => wrap.remove();
+}
+
 const control = {
   _container: null,
   onAdd() {
@@ -30,14 +59,17 @@ const control = {
       "maplibregl-ctrl maplibregl-ctrl-group geolibre-sample-plugin-control";
     const button = document.createElement("button");
     button.type = "button";
-    button.title = "GeoLibre Sample Plugin";
-    button.setAttribute("aria-label", "GeoLibre Sample Plugin");
+    button.title = "Open the Sample workbench panel";
+    button.setAttribute("aria-label", "Open the Sample workbench panel");
     button.appendChild(createStarIcon());
     button.addEventListener("click", () => {
-      // Non-blocking feedback for the template. A real plugin would act on the
-      // map here, e.g. app.addGeoJsonLayer(...) captured from activate(app).
-      button.classList.toggle("is-active");
-      console.info("GeoLibre Sample Plugin button clicked.");
+      // Open the right-sidebar panel where supported; otherwise just toggle a
+      // visual active state so the control still gives feedback on any host.
+      if (appApi?.openRightPanel) {
+        appApi.openRightPanel(RIGHT_PANEL_ID);
+      } else {
+        button.classList.toggle("is-active");
+      }
     });
     container.appendChild(button);
     this._container = container;
@@ -49,15 +81,102 @@ const control = {
   },
 };
 
+// Register the optional UI surfaces, collecting their disposers. Each register*
+// method is optional, so this degrades gracefully on hosts without them.
+function registerSurfaces(app) {
+  const keep = (dispose) => {
+    if (typeof dispose === "function") disposers.push(dispose);
+  };
+
+  keep(
+    app.registerRightPanel?.({
+      id: RIGHT_PANEL_ID,
+      title: "Sample Workbench",
+      defaultWidth: 320,
+      render: (container) =>
+        fillPanel(
+          container,
+          "Sample Workbench",
+          "A right-sidebar panel registered via app.registerRightPanel(). " +
+            "Click the star control or the Sample menu to open it; use the " +
+            "header buttons to move it left/right, collapse, or close.",
+        ),
+    }),
+  );
+
+  keep(
+    app.registerFloatingPanel?.({
+      id: FLOATING_PANEL_ID,
+      title: "Sample Tools",
+      defaultWidth: 280,
+      render: (container) =>
+        fillPanel(
+          container,
+          "Sample Tools",
+          "A draggable, closeable card over the map, registered via " +
+            "app.registerFloatingPanel(). Drag its title bar to move it.",
+        ),
+    }),
+  );
+
+  keep(
+    app.registerToolbarMenu?.({
+      id: TOOLBAR_MENU_ID,
+      label: "Sample",
+      items: [
+        {
+          id: "open-right",
+          label: "Open workbench panel",
+          disabled: !app.openRightPanel,
+          onSelect: () => app.openRightPanel?.(RIGHT_PANEL_ID),
+        },
+        {
+          type: "submenu",
+          id: "tools",
+          label: "Tools",
+          items: [
+            {
+              id: "open-floating",
+              label: "Open floating tools",
+              disabled: !app.openFloatingPanel,
+              onSelect: () => app.openFloatingPanel?.(FLOATING_PANEL_ID),
+            },
+          ],
+        },
+        { type: "separator" },
+        {
+          id: "close-panels",
+          label: "Close panels",
+          disabled: !app.closeRightPanel && !app.closeFloatingPanel,
+          onSelect: () => {
+            app.closeRightPanel?.(RIGHT_PANEL_ID);
+            app.closeFloatingPanel?.(FLOATING_PANEL_ID);
+          },
+        },
+      ],
+    }),
+  );
+}
+
 export const plugin = {
   id: "geolibre-sample-plugin",
   name: "Sample Plugin",
-  version: "1.0.0",
+  version: "1.1.0",
   activate(app) {
+    appApi = app;
     app.addMapControl(control, "top-right");
+    registerSurfaces(app);
   },
   deactivate(app) {
+    for (const dispose of disposers.splice(0)) {
+      try {
+        dispose();
+      } catch (error) {
+        console.error("Sample plugin cleanup failed.", error);
+      }
+    }
     app.removeMapControl(control);
+    appApi = null;
   },
 };
 

--- a/plugins/sample/plugin.json
+++ b/plugins/sample/plugin.json
@@ -1,8 +1,8 @@
 {
   "id": "geolibre-sample-plugin",
   "name": "Sample Plugin",
-  "version": "1.0.0",
-  "description": "A minimal example plugin that adds a button control to the map.",
+  "version": "1.1.0",
+  "description": "An example plugin that adds a map control and demonstrates the plugin UI surface APIs: a right-sidebar panel, a top toolbar menu, and a floating panel.",
   "entry": "index.js",
   "style": "style.css"
 }

--- a/plugins/sample/style.css
+++ b/plugins/sample/style.css
@@ -26,3 +26,29 @@
   background: hsl(var(--accent));
   color: hsl(var(--accent-foreground));
 }
+
+/*
+ * Body of the sample's right-sidebar and floating panels. The host provides the
+ * panel/card chrome and theme; the plugin only styles its own content, using
+ * GeoLibre's --foreground token so the text matches the light/dark theme.
+ */
+.geolibre-sample-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: hsl(var(--foreground));
+}
+
+.geolibre-sample-panel h2 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.geolibre-sample-panel p {
+  margin: 0;
+  opacity: 0.85;
+}


### PR DESCRIPTION
## Summary

Updates the marketplace **sample / template** plugin (`plugins/sample/`) to demonstrate the new optional plugin UI surface host APIs, so it can be installed from the registry to test them. Bumps it to **1.1.0** (existing installs get an Update action).

Alongside its existing theme-aware map control, the sample now registers:

- **`registerRightPanel`** — a "Sample Workbench" right-sidebar panel (opened by the star control or the Sample menu; movable left/right, collapsible, closeable).
- **`registerToolbarMenu`** — a top-level "Sample" menu with a Tools submenu, a separator, and items that open/close the panels. Items are `disabled` on hosts that lack the capability.
- **`registerFloatingPanel`** — a draggable "Sample Tools" card over the map.

Every UI-surface call is optional-chained, so the plugin degrades to a plain map control on a host without these APIs (so `minGeoLibreVersion` stays `0.9.0`). The new surfaces require a GeoLibre build with the plugin UI host API (opengeos/GeoLibre#705).

## Verification

`plugin.json` / `plugin-registry.json` JSON valid, entry passes `node --check`. Dropped the built bundle into a GeoLibre #705 build and drove it in a browser: the star control opens the Workbench panel (Style collapses), the Sample → Tools menu opens the floating card, and the close action tears both down — all with zero console errors.

`docs/plugins.md` is regenerated by the Pages workflow on merge, so it is not hand-edited here.