### PR TITLE
Add HyperCoast plugin to the registry

### DIFF
--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -44,6 +44,17 @@
       "manifestUrl": "plugins/geolibre-d2s/plugin.json",
       "categories": ["Data", "Imagery"],
       "minGeoLibreVersion": "0.9.0"
+    },
+    {
+      "id": "geolibre-hypercoast",
+      "name": "HyperCoast",
+      "version": "0.1.0",
+      "description": "Visualize and analyze hyperspectral imagery (EMIT, PACE, NEON, PRISMA, Tanager, AVIRIS, DESIS, EnMAP, Wyvern). Load a scene, build a wavelength-based RGB composite with adjustable bands and reflectance stretch, click pixels to plot reflectance spectra, and export the collected spectra to CSV. The control follows the host app's light/dark theme.",
+      "author": "Qiusheng Wu",
+      "homepage": "https://github.com/opengeos/geolibre-hypercoast",
+      "manifestUrl": "plugins/geolibre-hypercoast/plugin.json",
+      "categories": ["Data", "Imagery"],
+      "minGeoLibreVersion": "0.9.0"
     }
   ]
 }

--- a/plugins/geolibre-hypercoast/plugin.json
+++ b/plugins/geolibre-hypercoast/plugin.json
@@ -1,0 +1,8 @@
+{
+  "id": "geolibre-hypercoast",
+  "name": "HyperCoast",
+  "version": "0.1.0",
+  "entry": "index.js",
+  "description": "Visualize and analyze hyperspectral data (EMIT, PACE, NEON, PRISMA, Tanager, AVIRIS, DESIS, EnMAP, Wyvern) directly in GeoLibre.",
+  "style": "style.css"
+}

--- a/plugins/geolibre-hypercoast/style.css
+++ b/plugins/geolibre-hypercoast/style.css
@@ -1,0 +1,612 @@
+.uplot, .uplot *, .uplot *::before, .uplot *::after {box-sizing: border-box;}.uplot {font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";line-height: 1.5;width: min-content;}.u-title {text-align: center;font-size: 18px;font-weight: bold;}.u-wrap {position: relative;user-select: none;}.u-over, .u-under {position: absolute;}.u-under {overflow: hidden;}.uplot canvas {display: block;position: relative;width: 100%;height: 100%;}.u-axis {position: absolute;}.u-legend {font-size: 14px;margin: auto;text-align: center;}.u-inline {display: block;}.u-inline * {display: inline-block;}.u-inline tr {margin-right: 16px;}.u-legend th {font-weight: 600;}.u-legend th > * {vertical-align: middle;display: inline-block;}.u-legend .u-marker {width: 1em;height: 1em;margin-right: 4px;background-clip: padding-box !important;}.u-inline.u-live th::after {content: ":";vertical-align: middle;}.u-inline:not(.u-live) .u-value {display: none;}.u-series > * {padding: 4px;}.u-series th {cursor: pointer;}.u-legend .u-off > * {opacity: 0.3;}.u-select {background: rgba(0,0,0,0.07);position: absolute;pointer-events: none;}.u-cursor-x, .u-cursor-y {position: absolute;left: 0;top: 0;pointer-events: none;will-change: transform;}.u-hz .u-cursor-x, .u-vt .u-cursor-y {height: 100%;border-right: 1px dashed #607D8B;}.u-hz .u-cursor-y, .u-vt .u-cursor-x {width: 100%;border-bottom: 1px dashed #607D8B;}.u-cursor-pt {position: absolute;top: 0;left: 0;border-radius: 50%;border: 0 solid;pointer-events: none;will-change: transform;/*this has to be !important since we set inline "background" shorthand */background-clip: padding-box !important;}.u-axis.u-off, .u-select.u-off, .u-cursor-x.u-off, .u-cursor-y.u-off, .u-cursor-pt.u-off {display: none;}/**
+ * MapLibre GL Plugin Control Styles
+ *
+ * This stylesheet provides the base styles for the plugin control.
+ * Customize these styles to match your plugin's design.
+ *
+ * Colors are defined as CSS custom properties so the control adapts to the
+ * HOST APP's theme (light/dark). GeoLibre toggles a `.dark` class on an
+ * ancestor element (shadcn/tailwind convention), and the dark token block below
+ * keys off it. Override these variables to apply a custom theme.
+ */
+
+/*
+ * Theme tokens. Defined on both the container and the panel because the panel
+ * is appended to the map container (a separate DOM subtree from the control),
+ * so it cannot inherit variables scoped only to `.plugin-control`.
+ */
+.plugin-control,
+.plugin-control-panel {
+  --pc-bg: #fff;
+  --pc-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
+  --pc-icon: #1f2a37;
+  --pc-hover-bg: rgba(0, 0, 0, 0.05);
+  --pc-text: #333;
+  --pc-muted: #888;
+  --pc-label: #555;
+  --pc-border: #e0e0e0;
+  --pc-close: #999;
+  --pc-close-hover: #333;
+  --pc-scrollbar-thumb: #ccc;
+  --pc-scrollbar-thumb-hover: #aaa;
+  --pc-input-bg: #fff;
+  --pc-input-text: inherit;
+  --pc-input-border: #ddd;
+  --pc-accent: #4a90d9;
+  --pc-accent-hover: #3a7bc8;
+  --pc-accent-ring: rgba(74, 144, 217, 0.15);
+  /* Canvas spectrum chart (uPlot). Kept here so axis/grid colors live with the
+     rest of the palette; SpectrumChart reads these via getComputedStyle. */
+  --pc-chart-axis: #555555;
+  --pc-chart-grid: rgba(0, 0, 0, 0.08);
+}
+
+/*
+ * Dark theme: follows the HOST APP's theme, not the OS. GeoLibre toggles a
+ * `.dark` class on the document element (shadcn/tailwind convention), so we key
+ * the dark tokens off a `.dark` ancestor. (A `prefers-color-scheme` media query
+ * would wrongly show dark when the OS is dark but the app is in light mode.)
+ */
+.dark .plugin-control,
+.dark .plugin-control-panel {
+  --pc-bg: #1f2937;
+    --pc-shadow: 0 0 0 2px rgba(0, 0, 0, 0.4);
+    --pc-icon: #e5e7eb;
+    --pc-hover-bg: rgba(255, 255, 255, 0.08);
+    --pc-text: #e5e7eb;
+    --pc-muted: #9ca3af;
+    --pc-label: #cbd5e1;
+    --pc-border: #374151;
+    --pc-close: #9ca3af;
+    --pc-close-hover: #e5e7eb;
+    --pc-scrollbar-thumb: #4b5563;
+    --pc-scrollbar-thumb-hover: #6b7280;
+    --pc-input-bg: #111827;
+    --pc-input-text: #e5e7eb;
+    --pc-input-border: #4b5563;
+    --pc-accent: #4a90d9;
+    --pc-accent-hover: #5a9fe5;
+    --pc-accent-ring: rgba(74, 144, 217, 0.25);
+    --pc-chart-axis: #cbd5e1;
+    --pc-chart-grid: rgba(255, 255, 255, 0.12);
+}
+
+/*
+ * Container - matches maplibregl-ctrl styling.
+ * The `.maplibregl-ctrl-group` part raises specificity above MapLibre's own
+ * `.maplibregl-ctrl-group { background: #fff }` rule, which otherwise wins on
+ * source order and keeps the button white (poor contrast in dark mode).
+ */
+.maplibregl-ctrl-group.plugin-control {
+  background: var(--pc-bg);
+  border-radius: 4px;
+  box-shadow: var(--pc-shadow);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* Toggle button - 29x29 to match navigation control */
+.plugin-control-toggle {
+  background: none;
+  border: none;
+  padding: 0;
+  width: 29px;
+  height: 29px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  outline: none;
+  color: var(--pc-icon);
+}
+
+.plugin-control-toggle:hover {
+  background-color: var(--pc-hover-bg);
+}
+
+.plugin-control-toggle .plugin-control-icon {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 0;
+}
+
+.plugin-control-toggle .plugin-control-icon svg {
+  width: 22px;
+  height: 22px;
+  display: block;
+  stroke: currentColor;
+  fill: none;
+}
+
+/* Panel - positioned dynamically by JavaScript for floating behavior */
+.plugin-control-panel {
+  position: absolute;
+  /* Position is set dynamically by _updatePanelPosition() */
+  background: var(--pc-bg);
+  color: var(--pc-text);
+  border-radius: 4px;
+  box-shadow: var(--pc-shadow);
+  min-width: 260px;
+  max-width: 90vw;
+  min-height: 160px;
+  max-height: 85vh;
+  /* Width resizing is handled by custom grips on both edges (see
+     .plugin-control-resize-handle) so it works in any docking corner — the
+     native CSS `resize` grip only sits bottom-right and is unreachable when the
+     panel is anchored to the right. */
+  overflow: hidden;
+  z-index: 1000;
+  padding: 8px;
+  font-size: 12px;
+  line-height: 1.4;
+  display: none;
+}
+
+/* Panel scrollbar (the panel is the single scroll container). */
+.plugin-control-panel::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.plugin-control-panel::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.plugin-control-panel::-webkit-scrollbar-thumb {
+  background: var(--pc-scrollbar-thumb);
+  border-radius: 4px;
+}
+
+.plugin-control-panel::-webkit-scrollbar-thumb:hover {
+  background: var(--pc-scrollbar-thumb-hover);
+}
+
+/* Resize grips on all four edges, so width and height are both adjustable
+   whichever corner the panel is anchored in. */
+.plugin-control-resize-handle {
+  position: absolute;
+  z-index: 2;
+  touch-action: none;
+  user-select: none;
+}
+
+.plugin-control-resize-handle.left,
+.plugin-control-resize-handle.right {
+  top: 0;
+  width: 6px;
+  height: 100%;
+  cursor: ew-resize;
+}
+
+.plugin-control-resize-handle.left {
+  left: 0;
+}
+
+.plugin-control-resize-handle.right {
+  right: 0;
+}
+
+/* Inset horizontally so the top/bottom grips don't overlap the left/right ones
+   at the corners. */
+.plugin-control-resize-handle.top,
+.plugin-control-resize-handle.bottom {
+  left: 6px;
+  right: 6px;
+  height: 6px;
+  cursor: ns-resize;
+}
+
+.plugin-control-resize-handle.top {
+  top: 0;
+}
+
+.plugin-control-resize-handle.bottom {
+  bottom: 0;
+}
+
+.plugin-control-panel.expanded {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Panel header */
+.plugin-control-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  font-weight: 600;
+  color: var(--pc-text);
+  padding: 4px 0 8px 0;
+  border-bottom: 1px solid var(--pc-border);
+  margin-bottom: 8px;
+}
+
+.plugin-control-title {
+  flex: 1 1 auto;
+  font-size: 13px;
+}
+
+.plugin-control-close {
+  width: 20px;
+  height: 20px;
+  border: none;
+  background: transparent;
+  color: var(--pc-close);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+  transition: color 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.plugin-control-close:hover {
+  color: var(--pc-close-hover);
+}
+
+/* Content is the scroll container and a flex column so the chart can grow to
+   fill the height the panel gives it. */
+.plugin-control-content {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  /* No reserved right gutter: the scrollbar takes space only when the content
+     actually overflows, so there's no wide empty margin when it fits. */
+}
+
+.plugin-control-placeholder {
+  margin: 0;
+  color: var(--pc-muted);
+  font-size: 12px;
+  text-align: center;
+  padding: 16px 0;
+}
+
+/* Demo actions wiring the host callbacks (open folder, deep-link status) */
+.plugin-control-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.plugin-control-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 16px;
+  font-size: 14px;
+  font-weight: 500;
+  color: white;
+  background: var(--pc-accent);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.plugin-control-action:hover {
+  background: var(--pc-accent-hover);
+}
+
+.plugin-control-action:focus {
+  outline: 2px solid var(--pc-accent);
+  outline-offset: 2px;
+}
+
+.plugin-control-status {
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--pc-muted);
+  overflow-wrap: break-word;
+}
+
+.plugin-control-status:empty {
+  display: none;
+}
+
+/* Scrollbar styling */
+.plugin-control-content::-webkit-scrollbar {
+  width: 6px;
+}
+
+.plugin-control-content::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.plugin-control-content::-webkit-scrollbar-thumb {
+  background: var(--pc-scrollbar-thumb);
+  border-radius: 3px;
+}
+
+.plugin-control-content::-webkit-scrollbar-thumb:hover {
+  background: var(--pc-scrollbar-thumb-hover);
+}
+
+/* Form elements */
+.plugin-control-group {
+  margin-bottom: 12px;
+}
+
+.plugin-control-group:last-child {
+  margin-bottom: 0;
+}
+
+.plugin-control-label {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--pc-label);
+}
+
+.plugin-control-input {
+  width: 100%;
+  padding: 8px 10px;
+  font-size: 14px;
+  color: var(--pc-input-text);
+  background: var(--pc-input-bg);
+  border: 1px solid var(--pc-input-border);
+  border-radius: 4px;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.plugin-control-input:focus {
+  border-color: var(--pc-accent);
+  box-shadow: 0 0 0 3px var(--pc-accent-ring);
+}
+
+.plugin-control-select {
+  width: 100%;
+  padding: 8px 10px;
+  font-size: 14px;
+  color: var(--pc-input-text);
+  background: var(--pc-input-bg);
+  border: 1px solid var(--pc-input-border);
+  border-radius: 4px;
+  outline: none;
+  cursor: pointer;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.plugin-control-select:focus {
+  border-color: var(--pc-accent);
+  box-shadow: 0 0 0 3px var(--pc-accent-ring);
+}
+
+.plugin-control-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 16px;
+  font-size: 14px;
+  font-weight: 500;
+  color: white;
+  background: var(--pc-accent);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.plugin-control-button:hover {
+  background: var(--pc-accent-hover);
+}
+
+.plugin-control-button:focus {
+  outline: 2px solid var(--pc-accent);
+  outline-offset: 2px;
+}
+
+.plugin-control-button:disabled {
+  background: var(--pc-scrollbar-thumb);
+  cursor: not-allowed;
+}
+
+/* Utility classes */
+.plugin-control-flex {
+  display: flex;
+  gap: 8px;
+}
+
+.plugin-control-flex-col {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.plugin-control-divider {
+  height: 1px;
+  background: var(--pc-border);
+  margin: 12px 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* HyperCoast plugin UI                                                */
+/* ------------------------------------------------------------------ */
+
+.hypercoast-load {
+  width: 100%;
+}
+
+/* Loading indicator (spinner + message) shown while a scene loads. */
+.plugin-control-status.loading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--pc-text);
+}
+
+.hypercoast-spinner {
+  flex: 0 0 auto;
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--pc-border);
+  border-top-color: var(--pc-accent);
+  border-radius: 50%;
+  animation: hypercoast-spin 0.7s linear infinite;
+}
+
+@keyframes hypercoast-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.hypercoast-scene-info {
+  margin: 6px 0;
+  font-size: 11px;
+  color: var(--pc-muted);
+  overflow-wrap: break-word;
+}
+
+.hypercoast-scene-info:empty {
+  display: none;
+}
+
+/* Scene-dependent controls are hidden until a scene is loaded. */
+.hypercoast-controls {
+  display: none;
+  margin-top: 8px;
+}
+
+.hypercoast-controls.visible {
+  /* Flex column so the chart (flex: 1) fills remaining height on resize. */
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* RGB wavelength rows: colored tag, slider, numeric input. */
+.hypercoast-wavelength-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.hypercoast-channel-tag {
+  flex: 0 0 auto;
+  width: 18px;
+  height: 18px;
+  border-radius: 3px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 700;
+  color: #fff;
+}
+
+.hypercoast-channel-tag.red {
+  background: #d62728;
+}
+
+.hypercoast-channel-tag.green {
+  background: #2ca02c;
+}
+
+.hypercoast-channel-tag.blue {
+  background: #1f77b4;
+}
+
+.hypercoast-slider {
+  flex: 1 1 auto;
+  min-width: 0;
+  accent-color: var(--pc-accent);
+}
+
+.hypercoast-wavelength-num {
+  flex: 0 0 76px;
+  width: 76px;
+  padding: 7px 8px;
+  font-size: 13px;
+}
+
+.hypercoast-stretch .plugin-control-flex .plugin-control-input {
+  flex: 1 1 0;
+  width: 0;
+  padding: 7px 8px;
+  font-size: 13px;
+}
+
+/* Give the number spinners a usable hit target (Chromium/WebKit). */
+.hypercoast-wavelength-num::-webkit-inner-spin-button,
+.hypercoast-stretch .plugin-control-input::-webkit-inner-spin-button {
+  opacity: 1;
+  height: 20px;
+}
+
+/* Spectral inspector toggle: highlight when active. */
+.hypercoast-inspector {
+  width: 100%;
+}
+
+.hypercoast-inspector.active {
+  background: #2ca02c;
+}
+
+.hypercoast-inspector.active:hover {
+  background: #258a25;
+}
+
+.hypercoast-hint {
+  margin: 6px 0;
+  font-size: 11px;
+  color: var(--pc-muted);
+}
+
+/* Spectra output: hidden until the inspector is on, so an idle panel doesn't
+   reserve the chart's height as empty white space. When active it becomes the
+   flex region that grows with the panel. */
+.hypercoast-spectra {
+  display: none;
+}
+
+.hypercoast-controls.inspector-active .hypercoast-spectra {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* The chart grows to fill the height the panel gives it (min 160px), and its
+   width tracks the panel. A ResizeObserver in SpectrumChart syncs the canvas. */
+.hypercoast-chart {
+  margin: 8px 0;
+  flex: 1 1 auto;
+  min-height: 160px;
+  overflow: hidden;
+}
+
+.hypercoast-secondary {
+  flex: 1 1 0;
+  background: transparent;
+  color: var(--pc-accent);
+  border: 1px solid var(--pc-accent);
+}
+
+.hypercoast-secondary:hover {
+  background: var(--pc-accent-ring);
+}
+
+/* Keep uPlot's legend/axis text legible on the panel background. */
+.hypercoast-chart .u-legend {
+  font-size: 10px;
+  color: var(--pc-text);
+}
+
+.hypercoast-chart .u-legend .u-marker {
+  width: 8px;
+  height: 8px;
+}
+/*$vite$:1*/


### PR DESCRIPTION
## Summary

Adds the **HyperCoast** hyperspectral viewer plugin to the registry.

- New folder `plugins/geolibre-hypercoast/` with the built `index.js` entry, `style.css`, and `plugin.json` manifest (paths relative to the folder, matching the other plugins).
- New entry in `plugin-registry.json` pointing at `plugins/geolibre-hypercoast/plugin.json`, categorized under `Data` / `Imagery`, `minGeoLibreVersion` `0.9.0`.

## What the plugin does

Load a hyperspectral scene, build a wavelength-based RGB composite (adjustable R/G/B bands and reflectance stretch), click pixels to plot reflectance spectra, and export the collected spectra to CSV. Supports EMIT, PACE, NEON, PRISMA, Tanager, AVIRIS, DESIS, EnMAP, and Wyvern. The control follows the host app's light/dark theme (panel and the canvas spectrum chart both adapt live).

- Source: https://github.com/opengeos/geolibre-hypercoast

## Notes

- The bundle is self-contained (it bundles h5wasm, geotiff, deck.gl, proj4, etc. for in-browser hyperspectral reading), so `index.js` is larger than the other plugins; that is inherent to the data formats it reads.
- `docs/plugins.md` is intentionally not edited: CI regenerates it via `scripts/generate_plugins_page.py` on merge.