### PR TITLE
feat(sample): demonstrate the shared-rail (replace-style) dock mode

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -5,9 +5,21 @@ hide:
 
 # Plugins
 
-There are **2** plugins in the registry. Install them from GeoLibre: open **Settings → Manage Plugins**, then **Install** from the **All** or **Not installed** tab. No manual URL entry needed.
+There are **5** plugins in the registry. Install them from GeoLibre: open **Settings → Manage Plugins**, then **Install** from the **All** or **Not installed** tab. No manual URL entry needed.
 
 <div class="grid cards" markdown>
+
+-   :material-puzzle:{ .lg .middle } __Data to Science (D2S)__
+
+    ---
+
+    Browse and view Data to Science (D2S) projects, flights, and data products. Add raster data products as titiler tiles and project vector layers (FlatGeobuf) to the map, with automatic zoom to added layers.
+
+    **Author:** Qiusheng Wu · **Version:** 0.1.1 · **Requires:** GeoLibre 0.9.0+
+
+    `Data` `Imagery`
+
+    [:octicons-mark-github-16: Homepage](https://github.com/opengeos/geolibre-d2s){ target=_blank } · [:octicons-package-16: Manifest](https://plugins.geolibre.app/plugins/geolibre-d2s/plugin.json){ target=_blank }
 
 -   :material-puzzle:{ .lg .middle } __Elevation Profile__
 
@@ -21,13 +33,37 @@ There are **2** plugins in the registry. Install them from GeoLibre: open **Sett
 
     [:octicons-mark-github-16: Homepage](https://github.com/opengeos/geolibre-elevation-profile){ target=_blank } · [:octicons-package-16: Manifest](https://plugins.geolibre.app/plugins/geolibre-elevation-profile/plugin.json){ target=_blank }
 
+-   :material-puzzle:{ .lg .middle } __HyperCoast__
+
+    ---
+
+    Visualize and analyze hyperspectral imagery (EMIT, PACE, NEON, PRISMA, Tanager, AVIRIS, DESIS, EnMAP, Wyvern). Load a scene, build a wavelength-based RGB composite with adjustable bands and reflectance stretch, click pixels to plot reflectance spectra, and export the collected spectra to CSV. The control follows the host app's light/dark theme.
+
+    **Author:** Qiusheng Wu · **Version:** 0.1.0 · **Requires:** GeoLibre 0.9.0+
+
+    `Data` `Imagery`
+
+    [:octicons-mark-github-16: Homepage](https://github.com/opengeos/geolibre-hypercoast){ target=_blank } · [:octicons-package-16: Manifest](https://plugins.geolibre.app/plugins/geolibre-hypercoast/plugin.json){ target=_blank }
+
+-   :material-puzzle:{ .lg .middle } __NASA OPERA__
+
+    ---
+
+    Search NASA OPERA products (DSWx, RTC, CSLC, DIST) by area and date via NASA CMR, draw footprints, display Cloud-Optimized GeoTIFFs through titiler-cmr, click to inspect pixel values, compute zonal statistics over an AOI, and download granule data. No Earthdata login needed for search or display.
+
+    **Author:** Qiusheng Wu · **Version:** 0.2.1 · **Requires:** GeoLibre 0.9.0+
+
+    `Data` `Imagery`
+
+    [:octicons-mark-github-16: Homepage](https://github.com/opengeos/geolibre-nasa-opera){ target=_blank } · [:octicons-package-16: Manifest](https://plugins.geolibre.app/plugins/geolibre-nasa-opera/plugin.json){ target=_blank }
+
 -   :material-puzzle:{ .lg .middle } __Sample Plugin__
 
     ---
 
-    A minimal example plugin that adds a button control to the map. Use it as a template for marketplace entries.
+    An example plugin that adds a map control and demonstrates the plugin UI surface APIs: a shared-rail right-sidebar panel (dock: replace-style, sharing the Style rail), a top toolbar menu, and a floating panel. Use it as a template for marketplace entries.
 
-    **Author:** GeoLibre · **Version:** 1.0.0 · **Requires:** GeoLibre 0.9.0+
+    **Author:** GeoLibre · **Version:** 1.2.0 · **Requires:** GeoLibre 0.9.0+
 
     `Example`
 

--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -4,8 +4,8 @@
     {
       "id": "geolibre-sample-plugin",
       "name": "Sample Plugin",
-      "version": "1.1.0",
-      "description": "An example plugin that adds a map control and demonstrates the plugin UI surface APIs: a right-sidebar panel, a top toolbar menu, and a floating panel. Use it as a template for marketplace entries.",
+      "version": "1.2.0",
+      "description": "An example plugin that adds a map control and demonstrates the plugin UI surface APIs: a shared-rail right-sidebar panel (dock: replace-style, sharing the Style rail), a top toolbar menu, and a floating panel. Use it as a template for marketplace entries.",
       "author": "GeoLibre",
       "homepage": "https://github.com/opengeos/geolibre-plugins",
       "manifestUrl": "plugins/sample/plugin.json",

--- a/plugins/sample/index.js
+++ b/plugins/sample/index.js
@@ -3,9 +3,11 @@
 // GeoLibrePlugin contract, the same shape any external plugin must provide.
 //
 // Besides a theme-aware map control, it demonstrates the optional plugin UI
-// surface APIs: a right-sidebar panel, a top toolbar menu, and a floating
-// panel. Every UI-surface call is optional-chained, so on a host that does not
-// provide a given surface the plugin still works as a plain map control.
+// surface APIs: a right-sidebar panel (in the shared-rail "replace-style" mode,
+// where it shares the Style sidebar's single rail), a top toolbar menu, and a
+// floating panel. Every UI-surface call is optional-chained, so on a host that
+// does not provide a given surface the plugin still works as a plain map
+// control.
 // It ships style.css so its control and panels are theme-aware in light/dark.
 
 const SVG_NS = "http://www.w3.org/2000/svg";
@@ -92,14 +94,28 @@ function registerSurfaces(app) {
     app.registerRightPanel?.({
       id: RIGHT_PANEL_ID,
       title: "Sample Workbench",
+      // Shared-rail mode: the panel shares the Style sidebar's single rail
+      // instead of docking beside it. The host shows one far-right rail listing
+      // both this Workbench and Style; selecting one expands it while the other
+      // stays a rail entry, so a workbench-style plugin reads as a first-class
+      // right-sidebar workspace rather than a second rail next to Style.
+      //
+      // Other dock values: "left-of-layers", "right-of-layers", "left-of-style",
+      // "right-of-style" (the positional default). A host too old to know
+      // "replace-style" falls back to "right-of-style", so the panel still works
+      // as a normal dockable sidebar.
+      dock: "replace-style",
       defaultWidth: 320,
       render: (container) =>
         fillPanel(
           container,
           "Sample Workbench",
-          "A right-sidebar panel registered via app.registerRightPanel(). " +
-            "Click the star control or the Sample menu to open it; use the " +
-            "header buttons to move it left/right, collapse, or close.",
+          "A right-sidebar panel registered via app.registerRightPanel() with " +
+            'dock: "replace-style". It shares the Style panel\'s single rail: ' +
+            "the rail lists both this Workbench and Style, and opening one " +
+            "collapses the other, so you never see two adjacent rails. Click the " +
+            "star control or the Sample menu to open it; use the header buttons " +
+            "to collapse or close it, or pick Style in the rail to switch.",
         ),
     }),
   );
@@ -161,7 +177,7 @@ function registerSurfaces(app) {
 export const plugin = {
   id: "geolibre-sample-plugin",
   name: "Sample Plugin",
-  version: "1.1.0",
+  version: "1.2.0",
   activate(app) {
     appApi = app;
     app.addMapControl(control, "top-right");

--- a/plugins/sample/plugin.json
+++ b/plugins/sample/plugin.json
@@ -1,8 +1,8 @@
 {
   "id": "geolibre-sample-plugin",
   "name": "Sample Plugin",
-  "version": "1.1.0",
-  "description": "An example plugin that adds a map control and demonstrates the plugin UI surface APIs: a right-sidebar panel, a top toolbar menu, and a floating panel.",
+  "version": "1.2.0",
+  "description": "An example plugin that adds a map control and demonstrates the plugin UI surface APIs: a shared-rail right-sidebar panel (dock: replace-style), a top toolbar menu, and a floating panel.",
   "entry": "index.js",
   "style": "style.css"
 }


### PR DESCRIPTION
## Summary

GeoLibre's plugin right-panel API gained a non-positional **`replace-style`** dock (see opengeos/GeoLibre#769) that lets a workbench-style plugin **share the Style sidebar's single rail** instead of docking beside it: one far-right rail lists both the plugin and Style, and opening one collapses the other, so the user never sees two adjacent rails.

This updates the **Sample Plugin** (the marketplace template) to demonstrate the new mode.

## Changes

- **`plugins/sample/index.js`** — register the Sample Workbench with `dock: "replace-style"`, update the panel copy to explain the shared rail, and document the other dock values in a comment. Bumped to `1.2.0`.
- **`plugins/sample/plugin.json`** — version + description.
- **`plugin-registry.json`** — sample entry version + description.
- **`docs/plugins.md`** — regenerated from the registry (also syncs the D2S, NASA OPERA, and HyperCoast entries the committed page had not yet picked up).

## Compatibility

The mode degrades gracefully: a GeoLibre host too old to know `"replace-style"` normalizes it to `"right-of-style"`, so the workbench still works as a normal dockable sidebar. `minGeoLibreVersion` is therefore unchanged (`0.9.0`).

## Verification

Loaded the updated sample as a bundled drop-in into a GeoLibre build with the `replace-style` feature and drove it with Playwright: activating the plugin and opening the workbench (star control) shows **one** shared rail listing `Sample Workbench` + `Style`, with mutual-exclusive expand and no console errors.