### PR TITLE
Update Vantor Open Data bundle: theme sync

### DIFF
--- a/plugins/maplibre-gl-vantor/index.js
+++ b/plugins/maplibre-gl-vantor/index.js
@@ -1509,11 +1509,15 @@ class VantorControl {
 
 let control = null;
 let position = "top-left";
+let themeObserver = null;
+function hostTheme() {
+  return typeof document !== "undefined" && document.documentElement.classList.contains("dark") ? "dark" : "light";
+}
 function createControl(app) {
   return new VantorControl({
     collapsed: true,
     panelWidth: 380,
-    theme: "auto",
+    theme: hostTheme(),
     // Prefer the host's addCogLayer so COGs become native layers in the Layers
     // panel; fall back to the host's maplibre-gl-raster instance if absent.
     cogAdder: app.addCogLayer ? (name, url, options) => app.addCogLayer(name, url, options) : void 0,
@@ -1535,8 +1539,17 @@ const plugin = {
     if (isNew && app.setMapProjection) {
       control.getCogLayer()?.on("layeradd", () => app.setMapProjection("mercator"));
     }
+    if (!themeObserver && typeof MutationObserver !== "undefined") {
+      themeObserver = new MutationObserver(() => control?.setTheme(hostTheme()));
+      themeObserver.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ["class"]
+      });
+    }
   },
   deactivate(app) {
+    themeObserver?.disconnect();
+    themeObserver = null;
     if (!control) return;
     app.removeMapControl(control);
     control = null;


### PR DESCRIPTION
Refreshes `plugins/maplibre-gl-vantor/index.js` so the panel follows GeoLibre's light/dark theme (previously it followed the OS `prefers-color-scheme`, rendering dark in a light app and hurting dropdown contrast).

Includes the earlier Layers-panel integration (COGs via `app.addCogLayer`, helper layers flagged internal). Manifest/version unchanged (`0.1.0`).

Verified in GeoLibre: panel matches app theme (light + dark), dropdowns readable, and the visualized COG renders behind the panel (not over it).