### PR TITLE
chore: update Vantor Open Data plugin to 0.2.0

### DIFF
--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -59,7 +59,7 @@
     {
       "id": "maplibre-gl-vantor",
       "name": "Vantor Open Data",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "description": "Search, visualize, and download satellite imagery from the Vantor Open Data STAC catalog. Browse disaster event collections, filter by phase and map extent, view pre/post footprints, render Cloud-Optimized GeoTIFFs on the map, and download selected scenes.",
       "author": "Qiusheng Wu",
       "homepage": "https://github.com/opengeos/maplibre-gl-vantor",

--- a/plugins/maplibre-gl-vantor/index.js
+++ b/plugins/maplibre-gl-vantor/index.js
@@ -1515,7 +1515,7 @@ function hostTheme() {
 }
 function createControl(app) {
   return new VantorControl({
-    collapsed: true,
+    collapsed: false,
     panelWidth: 380,
     theme: hostTheme(),
     // Prefer the host's addCogLayer so COGs become native layers in the Layers
@@ -1527,7 +1527,7 @@ function createControl(app) {
 const plugin = {
   id: "maplibre-gl-vantor",
   name: "Vantor Open Data",
-  version: "0.1.0",
+  version: "0.2.0",
   activate(app) {
     const isNew = !control;
     control = control ?? createControl(app);
@@ -1539,7 +1539,7 @@ const plugin = {
     if (isNew && app.setMapProjection) {
       control.getCogLayer()?.on("layeradd", () => app.setMapProjection("mercator"));
     }
-    if (!themeObserver && typeof MutationObserver !== "undefined") {
+    if (!themeObserver && typeof document !== "undefined" && typeof MutationObserver !== "undefined") {
       themeObserver = new MutationObserver(() => control?.setTheme(hostTheme()));
       themeObserver.observe(document.documentElement, {
         attributes: true,

--- a/plugins/maplibre-gl-vantor/plugin.json
+++ b/plugins/maplibre-gl-vantor/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "maplibre-gl-vantor",
   "name": "Vantor Open Data",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "entry": "index.js",
   "description": "Search, visualize, and download satellite imagery from the Vantor Open Data STAC catalog.",
   "style": "style.css"

--- a/plugins/maplibre-gl-vantor/style.css
+++ b/plugins/maplibre-gl-vantor/style.css
@@ -307,16 +307,19 @@
   min-width: 0;
 }
 
-/* Select & Input styling */
-.vantor-panel select,
-.vantor-panel input[type='text'] {
+/* Select & Input styling. MapLibre ships `.maplibregl-ctrl select { color: #000
+   !important }`, which would force black text on the dark-theme dropdowns in a
+   host like GeoLibre. Match its `!important` and beat it on specificity (the
+   extra `.maplibregl-ctrl-vantor` class) so the theme's text color wins. */
+.maplibregl-ctrl-vantor .vantor-panel select,
+.maplibregl-ctrl-vantor .vantor-panel input[type='text'] {
   width: 100%;
   padding: 6px 8px;
   border: 1px solid var(--vantor-border);
   border-radius: 4px;
   font-size: 12px;
   background: var(--vantor-bg);
-  color: var(--vantor-text);
+  color: var(--vantor-text) !important;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
## Summary
- Bump the Vantor Open Data plugin to `0.2.0` in the registry entry and manifest.
- Refresh the bundled `index.js` and `style.css` from the 0.2.0 build.

This release makes the GeoLibre control open expanded on activation and fixes dark-mode dropdown text contrast (MapLibre's `.maplibregl-ctrl select` no longer forces black text).

## Test plan
- [x] Loaded the 0.2.0 bundle in GeoLibre: panel activates expanded, dark-mode dropdown text is light (`rgb(230,230,230)` on `rgb(30,30,30)`).
- [x] Registry entry version matches the exported plugin version (`0.2.0`).