### PR TITLE
chore: update Vantor Open Data plugin to 0.2.1

### DIFF
--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -59,7 +59,7 @@
     {
       "id": "maplibre-gl-vantor",
       "name": "Vantor Open Data",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "description": "Search, visualize, and download satellite imagery from the Vantor Open Data STAC catalog. Browse disaster event collections, filter by phase and map extent, view pre/post footprints, render Cloud-Optimized GeoTIFFs on the map, and download selected scenes.",
       "author": "Qiusheng Wu",
       "homepage": "https://github.com/opengeos/maplibre-gl-vantor",

--- a/plugins/maplibre-gl-vantor/index.js
+++ b/plugins/maplibre-gl-vantor/index.js
@@ -1527,7 +1527,7 @@ function createControl(app) {
 const plugin = {
   id: "maplibre-gl-vantor",
   name: "Vantor Open Data",
-  version: "0.2.0",
+  version: "0.2.1",
   activate(app) {
     const isNew = !control;
     control = control ?? createControl(app);

--- a/plugins/maplibre-gl-vantor/plugin.json
+++ b/plugins/maplibre-gl-vantor/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "maplibre-gl-vantor",
   "name": "Vantor Open Data",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "entry": "index.js",
   "description": "Search, visualize, and download satellite imagery from the Vantor Open Data STAC catalog.",
   "style": "style.css"

--- a/plugins/maplibre-gl-vantor/style.css
+++ b/plugins/maplibre-gl-vantor/style.css
@@ -68,6 +68,13 @@
 
 .maplibregl-ctrl-vantor {
   max-width: none !important;
+  /* Sit above map raster overlays that share this control corner. In GeoLibre
+     the COG deck.gl overlay (#deckgl-overlay) is an absolutely positioned,
+     full-map canvas mounted as a sibling control at z-index 1, so a static
+     control paints under it. Give the panel a stacking context above it,
+     mirroring GeoLibre's own .geolibre-stac-search-control (z-index: 3). */
+  position: relative;
+  z-index: 3;
 }
 
 .vantor-panel {


### PR DESCRIPTION
## Summary
- Bump the Vantor Open Data plugin to `0.2.1` in the registry entry and manifest.
- Refresh the bundled `index.js` and `style.css` from the 0.2.1 build.

This release keeps the panel above the host COG raster overlay (`z-index` fix) so the raster no longer covers the panel.

## Test plan
- [x] Registry entry version matches the exported plugin version (`0.2.1`).
- [x] Loaded the 0.2.1 bundle in GeoLibre: adding a COG that overlaps the panel no longer covers it.