### PR TITLE
Add plugin validation workflow

### DIFF
--- a/.github/workflows/test-plugins.yml
+++ b/.github/workflows/test-plugins.yml
@@ -1,0 +1,42 @@
+name: Test Plugins
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Validate plugin installation metadata
+        run: node scripts/validate_plugins.mjs
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Install docs dependencies
+        run: pip install -r requirements.txt
+
+      - name: Build docs and published bundle layout
+        run: |
+          python scripts/generate_plugins_page.py
+          mkdocs build --strict
+          cp plugin-registry.json site/
+          mkdir -p site/plugins
+          cp -r plugins/. site/plugins/
+          cp CNAME .nojekyll site/

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -7,6 +7,17 @@
   box-sizing: content-box;
 }
 
+.md-typeset .md-button + .md-button {
+  margin-left: 0.4rem;
+}
+
+@media screen and (max-width: 30em) {
+  .md-typeset .md-button + .md-button {
+    margin-top: 0.6rem;
+    margin-left: 0;
+  }
+}
+
 /* Tighten the plugin catalog cards and give each a clear footer of links. */
 .md-typeset .grid.cards > ul > li {
   border-radius: 0.5rem;

--- a/scripts/validate_plugins.mjs
+++ b/scripts/validate_plugins.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+
+import { fileURLToPath, pathToFileURL } from "node:url";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const registryPath = path.join(root, "plugin-registry.json");
+const errors = [];
+
+function addError(message) {
+  errors.push(message);
+}
+
+async function readJson(filePath, label) {
+  try {
+    return JSON.parse(await fs.readFile(filePath, "utf8"));
+  } catch (error) {
+    addError(`${label} is not valid JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function requireString(object, field, label) {
+  if (typeof object[field] !== "string" || object[field].trim() === "") {
+    addError(`${label} must define a non-empty string "${field}".`);
+    return false;
+  }
+  return true;
+}
+
+function resolveContainedPath(baseDir, relativePath, label) {
+  if (typeof relativePath !== "string" || relativePath.trim() === "") {
+    addError(`${label} must be a non-empty string.`);
+    return null;
+  }
+
+  if (path.isAbsolute(relativePath)) {
+    addError(`${label} must be relative, not absolute: ${relativePath}`);
+    return null;
+  }
+
+  const resolved = path.resolve(baseDir, relativePath);
+  const relative = path.relative(baseDir, resolved);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    addError(`${label} must stay inside ${path.relative(root, baseDir)}: ${relativePath}`);
+    return null;
+  }
+
+  return resolved;
+}
+
+async function fileExists(filePath, label) {
+  try {
+    const stat = await fs.stat(filePath);
+    if (!stat.isFile()) {
+      addError(`${label} is not a file: ${path.relative(root, filePath)}`);
+      return false;
+    }
+    return true;
+  } catch {
+    addError(`${label} does not exist: ${path.relative(root, filePath)}`);
+    return false;
+  }
+}
+
+async function validateLocalPlugin(registryEntry, manifestPath, label) {
+  const manifest = await readJson(manifestPath, `${label} manifest`);
+  if (!isPlainObject(manifest)) {
+    addError(`${label} manifest must be a JSON object.`);
+    return;
+  }
+
+  for (const field of ["id", "name", "version", "entry"]) {
+    requireString(manifest, field, `${label} manifest`);
+  }
+
+  for (const field of ["id", "name", "version"]) {
+    if (
+      typeof registryEntry[field] === "string" &&
+      typeof manifest[field] === "string" &&
+      registryEntry[field] !== manifest[field]
+    ) {
+      addError(
+        `${label} ${field} mismatch: registry has "${registryEntry[field]}", manifest has "${manifest[field]}".`,
+      );
+    }
+  }
+
+  const pluginDir = path.dirname(manifestPath);
+  const entryPath = resolveContainedPath(pluginDir, manifest.entry, `${label} entry`);
+  if (!entryPath || !(await fileExists(entryPath, `${label} entry`))) {
+    return;
+  }
+
+  if (manifest.style !== undefined) {
+    const stylePath = resolveContainedPath(pluginDir, manifest.style, `${label} style`);
+    if (stylePath) {
+      await fileExists(stylePath, `${label} style`);
+    }
+  }
+
+  let moduleExports;
+  try {
+    moduleExports = await import(pathToFileURL(entryPath).href);
+  } catch (error) {
+    addError(`${label} entry could not be imported: ${error.message}`);
+    return;
+  }
+
+  const plugin = moduleExports.plugin ?? moduleExports.default;
+  if (!isPlainObject(plugin)) {
+    addError(`${label} entry must export a plugin object as named "plugin" or default.`);
+    return;
+  }
+
+  for (const field of ["id", "name", "version"]) {
+    if (plugin[field] !== manifest[field]) {
+      addError(
+        `${label} exported plugin ${field} mismatch: plugin has "${plugin[field]}", manifest has "${manifest[field]}".`,
+      );
+    }
+  }
+
+  if (typeof plugin.activate !== "function") {
+    addError(`${label} exported plugin must define an activate(app) function.`);
+  }
+}
+
+async function main() {
+  const registry = await readJson(registryPath, "plugin-registry.json");
+  if (!isPlainObject(registry) || !Array.isArray(registry.plugins)) {
+    addError('plugin-registry.json must be an object with a "plugins" array.');
+  }
+
+  const plugins = Array.isArray(registry?.plugins) ? registry.plugins : [];
+  const seenIds = new Set();
+  const seenManifestUrls = new Set();
+
+  for (const [index, entry] of plugins.entries()) {
+    const label = `plugins[${index}]`;
+    if (!isPlainObject(entry)) {
+      addError(`${label} must be an object.`);
+      continue;
+    }
+
+    for (const field of ["id", "name", "version", "manifestUrl"]) {
+      requireString(entry, field, label);
+    }
+
+    if (typeof entry.id === "string") {
+      if (seenIds.has(entry.id)) {
+        addError(`Duplicate plugin id in registry: ${entry.id}`);
+      }
+      seenIds.add(entry.id);
+    }
+
+    if (typeof entry.homepage === "string" && !/^https?:\/\//.test(entry.homepage)) {
+      addError(`${label} homepage must use http(s): ${entry.homepage}`);
+    }
+
+    if (
+      entry.categories !== undefined &&
+      (!Array.isArray(entry.categories) ||
+        !entry.categories.every((category) => typeof category === "string" && category.trim() !== ""))
+    ) {
+      addError(`${label} categories must contain only non-empty strings.`);
+    }
+
+    if (typeof entry.manifestUrl !== "string") {
+      continue;
+    }
+
+    if (seenManifestUrls.has(entry.manifestUrl)) {
+      addError(`Duplicate manifestUrl in registry: ${entry.manifestUrl}`);
+    }
+    seenManifestUrls.add(entry.manifestUrl);
+
+    if (/^https:\/\//.test(entry.manifestUrl)) {
+      continue;
+    }
+    if (/^[a-z]+:\/\//i.test(entry.manifestUrl)) {
+      addError(`${label} manifestUrl must be relative or HTTPS: ${entry.manifestUrl}`);
+      continue;
+    }
+
+    const manifestPath = resolveContainedPath(root, entry.manifestUrl, `${label} manifestUrl`);
+    if (!manifestPath || !(await fileExists(manifestPath, `${label} manifest`))) {
+      continue;
+    }
+    await validateLocalPlugin(entry, manifestPath, `${label} (${entry.id ?? entry.manifestUrl})`);
+  }
+
+  if (errors.length > 0) {
+    console.error("Plugin validation failed:");
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`Validated ${plugins.length} plugin registry entries.`);
+}
+
+await main();


### PR DESCRIPTION
## Summary
- add a PR workflow that validates plugin registry entries, local manifests, bundled entry exports, and published site layout files
- catch install-time mismatches between registry, plugin.json, and exported plugin metadata
- fix the NetCDF exported version to match the manifest and registry
- add mobile spacing between homepage CTA buttons

## Testing
- node scripts/validate_plugins.mjs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated plugin validation in the release process to catch invalid or missing plugin metadata earlier.
  * Added a new plugins test workflow that runs on pull requests, main-branch pushes, and manual triggers.

* **Bug Fixes**
  * Improved the plugins page layout so adjacent buttons stack more cleanly on smaller screens.

* **Chores**
  * Updated the NetCDF plugin version to the latest patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->