### PR TITLE
Use unique Pages artifact names

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -61,8 +61,11 @@ jobs:
       - name: Upload site artifact
         uses: actions/upload-pages-artifact@v5
         with:
+          name: github-pages-${{ github.run_attempt }}
           path: site
 
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+        with:
+          artifact_name: github-pages-${{ github.run_attempt }}


### PR DESCRIPTION
## Summary
- make the Pages artifact name unique per workflow run attempt
- pass the same artifact name to deploy-pages so reruns do not collide with artifacts from earlier attempts

## Context
The failed deployment run found two artifacts named `github-pages` in attempt 2 of the same workflow run and deploy-pages refused to choose one.

## Testing
- node scripts/validate_plugins.mjs
- verified `actions/upload-pages-artifact@v5` supports `name` and `actions/deploy-pages@v5` supports `artifact_name`