### PR TITLE
Add per-PR plugin preview builds

### DIFF
--- a/.github/workflows/plugin-preview.yml
+++ b/.github/workflows/plugin-preview.yml
@@ -28,9 +28,15 @@ name: Plugin preview
 #
 # SETUP (one time)
 # Secret PREVIEW_DEPLOY_TOKEN: a fine-grained PAT scoped to
-# opengeos/geolibre-plugins-preview ONLY, with "Contents: Read and write".
-# It never needs access to this repository -- the sticky comment is posted with
-# this workflow's own GITHUB_TOKEN.
+# opengeos/geolibre-plugins-preview ONLY, with two permissions:
+#   Contents: Read and write   -- push the preview to gh-pages
+#   Pages:    Read             -- poll the Pages build so the comment is only
+#                                 posted once the URL actually resolves
+# Pages read is not optional: the wait polls /repos/.../pages/builds with this
+# token, and a token without it never sees a build, so the job spends the
+# timeout and then fails with "Timed out waiting for build to start".
+# The token never needs access to this repository -- the sticky comment is
+# posted with this workflow's own GITHUB_TOKEN.
 
 on:
   pull_request_target:
@@ -192,7 +198,11 @@ jobs:
       # On `closed` this removes pr-preview/pr-<N>/ instead of deploying.
       - name: Publish preview
         if: github.event.action == 'closed' || steps.select.outputs.found == 'true'
-        uses: rossjrw/pr-preview-action@v1
+        # Pinned to a SHA rather than the mutable v1 tag: unlike the first-party
+        # actions/* steps above, this is a third-party action and it receives
+        # PREVIEW_DEPLOY_TOKEN, so a moved tag would hand that token to code
+        # nobody reviewed.
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
         with:
           source-dir: geolibre/apps/geolibre-desktop/dist
           deploy-repository: opengeos/geolibre-plugins-preview
@@ -202,3 +212,6 @@ jobs:
           umbrella-dir: pr-preview
           pr-number: ${{ steps.pr.outputs.number }}
           action: ${{ github.event.action == 'closed' && 'remove' || 'deploy' }}
+          # Without this the sticky comment is posted as soon as the commit is
+          # pushed to gh-pages, so the link 404s until Pages finishes building.
+          wait-for-pages-deployment: true

--- a/.github/workflows/plugin-preview.yml
+++ b/.github/workflows/plugin-preview.yml
@@ -1,0 +1,204 @@
+name: Plugin preview
+
+# Builds GeoLibre with the plugin(s) touched by a pull request baked in, and
+# publishes it to opengeos/geolibre-plugins-preview under pr-preview/pr-<N>/.
+# A sticky comment carries the URL; the preview is deleted when the PR closes.
+#
+#   preview #N: https://opengeos.org/geolibre-plugins-preview/pr-preview/pr-<N>/
+#
+# HOW THE PLUGIN GETS IN
+# GeoLibre has a drop-in folder, apps/geolibre-desktop/public/plugins/, whose
+# README documents exactly this flow ("copy the plugin folder in at build/deploy
+# time"). A Vite plugin scans it at build start and the app loads whatever it
+# finds on startup, with no registry entry and no manifest URL. So this workflow
+# only has to copy the folder in before `npm run build` -- there is no registry
+# plumbing, and the PR's own plugin-registry.json is irrelevant here.
+#
+# WHY pull_request_target
+# Fork PRs get no secrets on `pull_request`, and fork PRs are the main case we
+# want previews for. The usual "pwn request" hazard does not apply: Vite copies
+# public/ verbatim without bundling or executing it, so the submitted plugin
+# never runs during the build -- only in the reviewer's browser, later, which is
+# the entire point of a preview. To keep it that way, this job:
+#   - copies ONLY plugins/<id>/ data directories out of the PR checkout,
+#   - never runs a script, install, or build step from that checkout,
+#   - rejects plugin ids that are not plain [A-Za-z0-9._-] names,
+#   - rejects symlinks, which would otherwise publish runner files to the site.
+# npm ci and the build run against opengeos/GeoLibre's own committed lockfile.
+#
+# SETUP (one time)
+# Secret PREVIEW_DEPLOY_TOKEN: a fine-grained PAT scoped to
+# opengeos/geolibre-plugins-preview ONLY, with "Contents: Read and write".
+# It never needs access to this repository -- the sticky comment is posted with
+# this workflow's own GITHUB_TOKEN.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, closed]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: PR number to build a preview for
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: plugin-preview-${{ github.event.pull_request.number || inputs.pr }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    name: Build and deploy preview
+    runs-on: ubuntu-latest
+    # Skip bot-authored PRs (e.g. a Dependabot bump touches no plugin anyway).
+    if: github.event_name == 'workflow_dispatch' || github.event.sender.type != 'Bot'
+    steps:
+      - name: Resolve target PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Via env, never interpolated straight into the script body.
+          NUMBER: ${{ github.event.pull_request.number || inputs.pr }}
+        run: |
+          set -euo pipefail
+          number="$NUMBER"
+          {
+            echo "number=$number"
+            gh api "repos/${{ github.repository }}/pulls/$number" \
+              --jq '"sha=\(.head.sha)\nrepo=\(.head.repo.full_name)"'
+          } >> "$GITHUB_OUTPUT"
+
+      # ---------------------------------------------------------------- build
+      - name: Check out the pull request (data only, never executed)
+        if: github.event.action != 'closed'
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ steps.pr.outputs.repo }}
+          ref: ${{ steps.pr.outputs.sha }}
+          path: plugins-pr
+          persist-credentials: false
+          fetch-depth: 1
+          # Required by checkout v7 to read fork PR code under
+          # pull_request_target. Safe here for the reasons in the header: only
+          # plugin data folders are copied out, and nothing from this checkout
+          # is ever executed.
+          allow-unsafe-pr-checkout: true
+
+      - name: Select the plugins this PR touches
+        if: github.event.action != 'closed'
+        id: select
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          ids=$(gh api --paginate "repos/${{ github.repository }}/pulls/$PR/files" \
+                  --jq '.[].filename' \
+                | awk -F/ '$1 == "plugins" && NF > 2 { print $2 }' | sort -u)
+          selected=()
+          for id in $ids; do
+            # Reject anything that is not a plain directory name, so a crafted
+            # path cannot escape plugins/ when it is used below.
+            if ! printf '%s' "$id" | grep -qE '^[A-Za-z0-9._-]+$'; then
+              echo "::error::Refusing suspicious plugin directory name: $id"
+              exit 1
+            fi
+            dir="plugins-pr/plugins/$id"
+            # A deleted plugin has changed files but no directory; skip it.
+            [ -f "$dir/plugin.json" ] || continue
+            # Symlinks would let a PR publish arbitrary runner files (including
+            # anything the build wrote) to a public site. Refuse outright.
+            if [ -n "$(find "$dir" -type l -print -quit)" ]; then
+              echo "::error::Plugin $id contains a symlink; refusing to publish it."
+              exit 1
+            fi
+            selected+=("$id")
+          done
+          if [ ${#selected[@]} -eq 0 ]; then
+            echo "No plugin directories changed; skipping preview."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Selected: ${selected[*]}"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "ids=${selected[*]}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check out GeoLibre
+        if: github.event.action != 'closed' && steps.select.outputs.found == 'true'
+        uses: actions/checkout@v7
+        with:
+          repository: opengeos/GeoLibre
+          path: geolibre
+          persist-credentials: false
+
+      - name: Bake the plugins into the build
+        if: github.event.action != 'closed' && steps.select.outputs.found == 'true'
+        env:
+          IDS: ${{ steps.select.outputs.ids }}
+        run: |
+          set -euo pipefail
+          dest=geolibre/apps/geolibre-desktop/public/plugins
+          mkdir -p "$dest"
+          for id in $IDS; do
+            cp -r "plugins-pr/plugins/$id" "$dest/$id"
+            echo "baked in: $id"
+          done
+          ls -la "$dest"
+
+      - name: Set up Node.js
+        if: github.event.action != 'closed' && steps.select.outputs.found == 'true'
+        uses: actions/setup-node@v7
+        with:
+          node-version: lts/*
+          cache: npm
+          cache-dependency-path: geolibre/package-lock.json
+
+      - name: Install dependencies
+        if: github.event.action != 'closed' && steps.select.outputs.found == 'true'
+        working-directory: geolibre
+        run: npm ci
+
+      - name: Build the web app
+        if: github.event.action != 'closed' && steps.select.outputs.found == 'true'
+        working-directory: geolibre
+        env:
+          # Relative base: the preview is served from a subdirectory, not root.
+          GEOLIBRE_APP_BASE: ./
+          # Optional. Absent secrets resolve to "" and simply disable the
+          # corresponding data source, which does not affect plugin testing.
+          VITE_GEE_OAUTH_CLIENT_ID: ${{ secrets.VITE_GEE_OAUTH_CLIENT_ID }}
+          VITE_PROTOMAPS_API_KEY: ${{ secrets.VITE_PROTOMAPS_API_KEY }}
+          VITE_MAPILLARY_ACCESS_TOKEN: ${{ secrets.VITE_MAPILLARY_ACCESS_TOKEN }}
+        run: npm run build -w geolibre-desktop
+
+      - name: Check the build fits GitHub Pages
+        if: github.event.action != 'closed' && steps.select.outputs.found == 'true'
+        run: |
+          set -euo pipefail
+          dist=geolibre/apps/geolibre-desktop/dist
+          echo "preview size: $(du -sh "$dist" | cut -f1)"
+          # 104857600 bytes = 100 MB, the Pages per-file hard limit.
+          oversized=$(find "$dist" -type f -size +104857600c -printf '%s\t%p\n' || true)
+          if [ -n "$oversized" ]; then
+            echo "::error::Files exceed the 100 MB GitHub Pages limit:"
+            echo "$oversized"
+            exit 1
+          fi
+
+      # --------------------------------------------------------------- deploy
+      # On `closed` this removes pr-preview/pr-<N>/ instead of deploying.
+      - name: Publish preview
+        if: github.event.action == 'closed' || steps.select.outputs.found == 'true'
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: geolibre/apps/geolibre-desktop/dist
+          deploy-repository: opengeos/geolibre-plugins-preview
+          token: ${{ secrets.PREVIEW_DEPLOY_TOKEN }}
+          pages-base-url: opengeos.org/geolibre-plugins-preview
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          pr-number: ${{ steps.pr.outputs.number }}
+          action: ${{ github.event.action == 'closed' && 'remove' || 'deploy' }}

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -89,6 +89,22 @@ that has not been formatted will fail CI.
 
 ## 6. Open a pull request
 
+Every pull request that touches `plugins/<id>/` gets a live preview: CI builds
+GeoLibre with your plugin baked in and posts the URL as a comment.
+
+```text
+https://opengeos.org/geolibre-plugins-preview/pr-preview/pr-<N>/
+```
+
+Your plugin loads automatically there, so you can exercise it in the real app
+before review. The preview rebuilds on every push and is deleted when the pull
+request closes.
+
+!!! warning "Previews run unreviewed code"
+    A preview executes the pull request's plugin with full app privileges in
+    your browser. Open previews only for pull requests you are reviewing.
+
+
 On merge to `main`, the Pages workflow publishes the update to
 `plugins.geolibre.app` and the new plugin appears in the catalog and in
 GeoLibre's Manage Plugins dialog.


### PR DESCRIPTION
## Summary

Builds GeoLibre with the plugin(s) a pull request touches baked in, publishes it to `opengeos/geolibre-plugins-preview` under `pr-preview/pr-<N>/`, and posts a sticky comment with the URL. The preview rebuilds on every push and is deleted when the PR closes.

```
https://opengeos.org/geolibre-plugins-preview/pr-preview/pr-<N>/
```

Uses GeoLibre's documented `apps/geolibre-desktop/public/plugins/` drop-in folder, whose README describes exactly this flow ("copy the plugin folder in at build/deploy time"). A Vite plugin scans it at build start and the app loads what it finds on startup, so there is no registry plumbing: no jsDelivr, no `VITE_GEOLIBRE_PLUGIN_REGISTRY_URL`, no cross-repo dispatch, and the PR's own `plugin-registry.json` is not involved.

Previews go to a separate repo so production `plugins.geolibre.app` keeps its current artifact-based Pages deploy untouched, and so the preview branch's history stays disposable.

## Security

Runs on `pull_request_target`, because fork PRs get no secrets on `pull_request` and fork PRs are the main case worth previewing. The usual pwn-request hazard does not apply: Vite copies `public/` verbatim without bundling or executing it, so the submitted plugin never runs during the build. It runs only in the reviewer's browser afterwards, which is the point of a preview. To keep it that way the job:

- copies only `plugins/<id>/` data directories out of the PR checkout
- never runs a script, install, or build step from that checkout (`npm ci` uses GeoLibre's own committed lockfile)
- rejects plugin ids that are not plain `[A-Za-z0-9._-]` names
- rejects symlinks, which would otherwise publish runner files to a public site
- passes all untrusted values through `env:` rather than interpolating into `run:`

## Required setup before this works

Repository secret `PREVIEW_DEPLOY_TOKEN`: a fine-grained PAT scoped to `opengeos/geolibre-plugins-preview` only, with **two** permissions:

| Permission | Why |
| --- | --- |
| `Contents: Read and write` | push the preview to `gh-pages` |
| `Pages: Read` | poll the Pages build so the comment is only posted once the URL resolves |

`Pages: Read` is not optional. The wait polls `/repos/.../pages/builds` with this token, and a token without it never sees a build, so the job spends the timeout and then fails with a misleading "Timed out waiting for build to start".

The token needs no access to this repository, since the sticky comment is posted with the workflow's own `GITHUB_TOKEN`.

## Test plan

- [x] `actionlint` clean on this workflow and the four existing ones
- [x] `pre-commit run --all-files` passes
- [x] Preview repo created, `gh-pages` seeded, Pages enabled and serving (`200` at the base URL)
- [ ] Add `PREVIEW_DEPLOY_TOKEN`
- [ ] After merge, `workflow_dispatch` against PR #35 and confirm the preview loads the Flowmaps plugin

Note that `pull_request_target` and `workflow_dispatch` both run the workflow from the default branch, so this cannot be exercised until it lands on `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated live previews for pull requests that modify plugins.
  * Previews build with the changed plugins and are published as temporary websites.
  * Preview links are updated with each push and removed when the pull request closes.

* **Documentation**
  * Added contributor guidance for accessing plugin previews.
  * Documented preview behavior and security considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
