### PR TITLE
Fix preview deploy failing with "not in a git directory"

### DIFF
--- a/.github/workflows/plugin-preview.yml
+++ b/.github/workflows/plugin-preview.yml
@@ -62,6 +62,17 @@ jobs:
     # Skip bot-authored PRs (e.g. a Dependabot bump touches no plugin anyway).
     if: github.event_name == 'workflow_dispatch' || github.event.sender.type != 'Bot'
     steps:
+      # The publish step runs `git config user.name` in the workspace root, so
+      # that root has to be a git repository. Both checkouts below use `path:`,
+      # which would leave it bare and fail the deploy with "not in a git
+      # directory". This is the base branch (pull_request_target), so it is our
+      # own trusted code, and nothing here is executed either way.
+      - name: Check out this repository into the workspace root
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
       - name: Resolve target PR
         id: pr
         env:


### PR DESCRIPTION
## Summary

The first real run of the preview workflow (against #35) failed at the publish step:

```
git config user.name giswqs
fatal: not in a git directory
There was an error initializing the repository: The process '/usr/bin/git' failed with exit code 128
```

`pr-preview-action` delegates to `JamesIves/github-pages-deploy-action`, which runs `git config user.name` (no `--global`) in the workspace root. Both of the workflow's checkouts use `path:`, so the root was never a git repository and every deploy would have failed. Checking this repository out at the root as well fixes it, and matches how the reference workflow in `opengeos/geolibre-rust` is laid out.

## Everything else already works

The run got all the way to the deploy, so the parts that were previously unverified are now confirmed against a real fork PR:

| Step | Result |
| --- | --- |
| Select the plugins this PR touches | `geolibre-plugin-flowmaps` |
| Bake the plugins into the build | ok |
| `npm ci` | ok |
| `npm run build -w geolibre-desktop` | ok |
| Check the build fits GitHub Pages | ok, 182 MB, no file over the per-file limit |

## Test plan

- [x] `actionlint` clean
- [x] `pre-commit` clean
- [ ] After merge, `gh workflow run plugin-preview.yml -f pr=35` and confirm the sticky comment appears and the URL loads the Flowmaps plugin

Note `pull_request_target` runs the workflow from the default branch, so this cannot be exercised on its own PR.