### PR TITLE
Fix preview dropping the plugin it was built to show

### DIFF
--- a/.github/workflows/plugin-preview.yml
+++ b/.github/workflows/plugin-preview.yml
@@ -191,6 +191,38 @@ jobs:
           VITE_MAPILLARY_ACCESS_TOKEN: ${{ secrets.VITE_MAPILLARY_ACCESS_TOKEN }}
         run: npm run build -w geolibre-desktop
 
+      # Vite copies public/ verbatim, so GeoLibre's public/plugins/.gitignore
+      # ("*", keeping only itself and README.md -- it exists so private plugin
+      # bundles stay out of that repo's history) lands in dist/plugins/. The
+      # deploy step publishes by running `git add`, which HONORS that file and
+      # silently drops the plugin we just baked in: the build looks fine, the
+      # site 404s on plugin.json. Strip every .gitignore from the output, not
+      # just that one, since a submitted plugin can ship its own.
+      - name: Strip .gitignore files that would exclude the build from the deploy
+        if: github.event.action != 'closed' && steps.select.outputs.found == 'true'
+        run: |
+          set -euo pipefail
+          find geolibre/apps/geolibre-desktop/dist -name .gitignore -print -delete
+
+      # The plugin reaching dist/ is the entire point of this workflow, and the
+      # .gitignore bug above proved a green build says nothing about that. Fail
+      # here rather than shipping a preview that 404s on its own plugin.
+      - name: Verify the plugins reached the build output
+        if: github.event.action != 'closed' && steps.select.outputs.found == 'true'
+        env:
+          IDS: ${{ steps.select.outputs.ids }}
+        run: |
+          set -euo pipefail
+          dist=geolibre/apps/geolibre-desktop/dist
+          for id in $IDS; do
+            if [ ! -f "$dist/plugins/$id/plugin.json" ]; then
+              echo "::error::$id is missing from the build output ($dist/plugins/$id/plugin.json)."
+              find "$dist/plugins" -maxdepth 2 || true
+              exit 1
+            fi
+            echo "present in build: $id"
+          done
+
       - name: Check the build fits GitHub Pages
         if: github.event.action != 'closed' && steps.select.outputs.found == 'true'
         run: |


### PR DESCRIPTION
## The bug

The preview for #35 deployed and loaded, but the app 404d on its own plugin:

```
GET .../pr-preview/pr-35/plugins/geolibre-plugin-flowmaps/plugin.json  →  404
Skipped external plugin archive: Could not fetch plugin manifest: HTTP 404
```

The deployed directory contained exactly two files:

```
pr-preview/pr-35/plugins/.gitignore
pr-preview/pr-35/plugins/README.md
```

Which are precisely the two files GeoLibre's `apps/geolibre-desktop/public/plugins/.gitignore` un-ignores:

```gitignore
*
!.gitignore
!README.md
```

That file exists so private plugin bundles stay out of GeoLibre's history. Vite copies `public/` verbatim, so it lands in `dist/plugins/`. The deploy step publishes by running `git add`, which **honors** it and silently excluded the plugin we had just baked in. The build was correct; the commit threw the plugin away.

## The fix

- Strip every `.gitignore` from the build output before deploying. Not just that one, since a submitted plugin can ship its own and cause the same silent exclusion.
- Assert each selected plugin is present at `dist/plugins/<id>/plugin.json` before deploying. The plugin reaching `dist/` is the whole point of this workflow, and this bug proved a green build says nothing about it. Better to fail the job than hand a reviewer a preview that 404s on the plugin under review.

## Test plan

- [x] `actionlint` clean
- [x] `pre-commit` clean
- [ ] After merge, re-run for #35 and confirm `pr-preview/pr-35/plugins/geolibre-plugin-flowmaps/` contains the bundle and the app loads it

Note the plugin itself still has the unrelated `window is not defined` import failure from #35, so `validate` there stays red until the contributor rebuilds. That does not block the preview.