### PR TITLE
Publish previews to the shared opengeos/pages-preview site

### DIFF
--- a/.github/workflows/plugin-preview.yml
+++ b/.github/workflows/plugin-preview.yml
@@ -1,10 +1,10 @@
 name: Plugin preview
 
 # Builds GeoLibre with the plugin(s) touched by a pull request baked in, and
-# publishes it to opengeos/geolibre-plugins-preview under pr-preview/pr-<N>/.
+# publishes it to opengeos/pages-preview under geolibre-plugins/pr-<N>/.
 # A sticky comment carries the URL; the preview is deleted when the PR closes.
 #
-#   preview #N: https://opengeos.org/geolibre-plugins-preview/pr-preview/pr-<N>/
+#   preview #N: https://opengeos.org/pages-preview/geolibre-plugins/pr-<N>/
 #
 # HOW THE PLUGIN GETS IN
 # GeoLibre has a drop-in folder, apps/geolibre-desktop/public/plugins/, whose
@@ -28,7 +28,7 @@ name: Plugin preview
 #
 # SETUP (one time)
 # Secret PREVIEW_DEPLOY_TOKEN: a fine-grained PAT scoped to
-# opengeos/geolibre-plugins-preview ONLY, with two permissions:
+# opengeos/pages-preview ONLY, with two permissions:
 #   Contents: Read and write   -- push the preview to gh-pages
 #   Pages:    Read             -- poll the Pages build so the comment is only
 #                                 posted once the URL actually resolves
@@ -248,11 +248,15 @@ jobs:
         uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
         with:
           source-dir: geolibre/apps/geolibre-desktop/dist
-          deploy-repository: opengeos/geolibre-plugins-preview
+          deploy-repository: opengeos/pages-preview
           token: ${{ secrets.PREVIEW_DEPLOY_TOKEN }}
-          pages-base-url: opengeos.org/geolibre-plugins-preview
+          pages-base-url: opengeos.org/pages-preview
           preview-branch: gh-pages
-          umbrella-dir: pr-preview
+          # pages-preview is shared across opengeos repositories, and the action
+          # composes the path as "<umbrella-dir>/pr-<number>". Namespacing by
+          # this repository's name is what keeps our pr-35 from colliding with
+          # another repository's pr-35.
+          umbrella-dir: geolibre-plugins
           pr-number: ${{ steps.pr.outputs.number }}
           action: ${{ github.event.action == 'closed' && 'remove' || 'deploy' }}
           # Without this the sticky comment is posted as soon as the commit is

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -93,7 +93,7 @@ Every pull request that touches `plugins/<id>/` gets a live preview: CI builds
 GeoLibre with your plugin baked in and posts the URL as a comment.
 
 ```text
-https://opengeos.org/geolibre-plugins-preview/pr-preview/pr-<N>/
+https://opengeos.org/pages-preview/geolibre-plugins/pr-<N>/
 ```
 
 Your plugin loads automatically there, so you can exercise it in the real app


### PR DESCRIPTION
## Summary

Moves plugin previews off the single-purpose `geolibre-plugins-preview` repo and onto [`opengeos/pages-preview`](https://github.com/opengeos/pages-preview), a central host other opengeos repositories can share.

```
https://opengeos.org/pages-preview/geolibre-plugins/pr-<N>/
https://opengeos.org/pages-preview/<other-repo>/pr-<N>/
```

`pr-preview-action` composes the deploy path as `"<umbrella-dir>/pr-<number>"`, so setting `umbrella-dir` to this repository's name namespaces our previews and keeps our `pr-35` from colliding with another repository's `pr-35`.

## Already set up

- `opengeos/pages-preview` created, `gh-pages` seeded, Pages enabled and serving (`200` at the base URL, build `built`).
- Its README documents the layout, the deploy-token scopes, and a copy-pasteable job for onboarding another repository — including the two failure modes this workflow hit in #39 and #40 (`.gitignore` files in the payload, and absolute base paths), so the next repo does not rediscover them.

## Action required before merge

`PREVIEW_DEPLOY_TOKEN` is currently scoped to `opengeos/geolibre-plugins-preview`. It needs to be re-scoped (or reissued) for `opengeos/pages-preview`, same two permissions: `Contents: Read and write` and `Pages: Read`. Without that the deploy fails at the push.

## Note on naming

The request was for `repo-name-pr-number`. The action hardcodes its path as `"$umbrella_path/pr-$pr_number"`, so a literal flat `geolibre-plugins-pr-35` is not reachable through it — that would mean dropping the action and reimplementing the sticky comment, the Pages wait, and the close-cleanup by hand. `geolibre-plugins/pr-35` gives the same collision-free namespacing without giving those up. Easy to change if the flat form matters.

## Test plan

- [x] `actionlint` clean
- [x] `pre-commit` clean
- [x] `opengeos.org/pages-preview/` returns 200
- [ ] Re-scope `PREVIEW_DEPLOY_TOKEN`
- [ ] After merge, re-run for #35 and confirm the preview lands at `/pages-preview/geolibre-plugins/pr-35/` with the plugin loading

Once that is confirmed, `opengeos/geolibre-plugins-preview` can be deleted.